### PR TITLE
Add tests for "II architecture" part; fix testbench for simple/memory;

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-SUBDIRS := bigsim simple
+SUBDIRS := bigsim simple architecture
 
 ifeq ($(VERIFIC),1)
 export VERIFIC=1

--- a/architecture/.gitignore
+++ b/architecture/.gitignore
@@ -1,0 +1,2 @@
+/alu/work_*/
+/.stamp

--- a/architecture/Makefile
+++ b/architecture/Makefile
@@ -1,0 +1,56 @@
+all: work
+	touch .stamp
+
+clean::
+	rm -f .stamp
+
+define template
+$(foreach design,$(1),
+$(foreach script,$(2),
+work:: $(design)/work_$(script)/.stamp
+
+$(design)/work_$(script)/.stamp:
+	bash run.sh $(design) $(script)
+
+clean::
+	rm -rf $(design)/work_$(script)
+))
+endef
+
+#achronix (in the code '-flatten' but in the help '-noflatten')
+$(eval $(call template,synth_achronix,synth_achronix synth_achronix_top synth_achronix_vout synth_achronix_run synth_achronix_noflatten synth_achronix_retime))
+
+#coolrunner2
+$(eval $(call template,synth_coolrunner2,synth_coolrunner2 synth_coolrunner2_top synth_coolrunner2_vout synth_coolrunner2_run synth_coolrunner2_noflatten synth_coolrunner2_retime))
+
+#easic
+#$(eval $(call template,synth_easic,synth_easic synth_easic_top synth_easic_vlog synth_easic_run synth_easic_noflatten synth_easic_retime))
+
+#ecp5
+$(eval $(call template,synth_ecp5,synth_ecp5 synth_ecp5_top synth_ecp5_blif synth_ecp5_edif synth_ecp5_json synth_ecp5_run synth_ecp5_flatten synth_ecp5_noflatten synth_ecp5_retime synth_ecp5_noccu2 synth_ecp5_nodffe synth_ecp5_nobram synth_ecp5_nodram synth_ecp5_nomux synth_ecp5_abc2 synth_ecp5_vpr))
+
+#gowin
+$(eval $(call template,synth_gowin,synth_gowin synth_gowin_top synth_gowin_vout synth_gowin_run synth_gowin_retime))
+
+#ice40
+$(eval $(call template,synth_ice40,synth_ice40 synth_ice40_top synth_ice40_blif synth_ice40_edif synth_ice40_json synth_ice40_run synth_ice40_noflatten synth_ice40_flatten synth_ice40_retime synth_ice40_nocarry synth_ice40_nodffe synth_ice40_nobram synth_ice40_abc2 synth_ice40_vpr))
+
+#intel (in the code '-flatten' but in the help '-noflatten')
+$(eval $(call template,synth_intel,synth_intel synth_intel_top synth_intel_vqm synth_intel_vpr synth_intel_run synth_intel_noflatten synth_intel_retime synth_intel_noiopads synth_intel_nobram synth_intel_max10 ))
+$(eval $(call template,synth_intel_cycloneiv,synth_intel_cycloneiv  ))
+$(eval $(call template,synth_intel_cycloneive,synth_intel_cycloneive   ))
+#../../../../../techlibs/intel/cyclonev/cells_sim.v:88: error: Unable to bind wire/reg/memory `upper_mask_value' in `testbench.uut._05_.lut5'
+#$(eval $(call template,synth_intel_cyclonev ,synth_intel_cyclonev ))
+$(eval $(call template,synth_intel_cyclone10,synth_intel_cyclone10  ))
+$(eval $(call template,synth_intel_a10gx ,synth_intel_a10gx ))
+
+#sf2
+$(eval $(call template,synth_sf2,synth_sf2 synth_sf2_top synth_sf2_edif synth_sf2_json synth_sf2_run synth_sf2_noflatten synth_sf2_retime ))
+
+#xilinx
+$(eval $(call template,synth_xilinx,synth_xilinx synth_xilinx_top synth_xilinx_blif synth_xilinx_edif synth_xilinx_run synth_xilinx_flatten synth_xilinx_retime synth_xilinx_vpr))
+
+#greenpak4
+$(eval $(call template,synth_greenpak4,synth_greenpak4 synth_greenpak4_top synth_greenpak4_json synth_greenpak4_run synth_greenpak4_noflatten synth_greenpak4_retime synth_greenpak4_part621 synth_greenpak4_part620 synth_greenpak4_part140))
+
+.PHONY: all clean

--- a/architecture/common.v
+++ b/architecture/common.v
@@ -1,0 +1,46 @@
+module assert_dff(input clk, input test, input pat);
+    always @(posedge clk)
+    begin
+        if (test != pat)
+        begin
+            $display("ERROR: ASSERTION FAILED in %m:",$time);
+            $stop;
+        end
+    end
+endmodule 
+
+module assert_tri(input en, input A, input B);
+    always @(posedge en)
+    begin
+        //#1;
+        if (A !== B)
+        begin
+            $display("ERROR: ASSERTION FAILED in %m:",$time," ",A," ",B);
+            $stop;
+        end
+    end
+endmodule
+
+module assert_Z(input clk, input A);
+    always @(posedge clk)
+    begin
+        //#1;
+        if (A === 1'bZ)
+        begin
+            $display("ERROR: ASSERTION FAILED in %m:",$time," ",A);
+            $stop;
+        end
+    end
+endmodule
+
+module assert_comb(input A, input B);
+    always @(*)
+    begin
+        #1;
+        if (A !== B)
+        begin
+            $display("ERROR: ASSERTION FAILED in %m:",$time," ",A," ",B);
+            $stop;
+        end
+    end
+endmodule

--- a/architecture/run.sh
+++ b/architecture/run.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -ex
+test -d $1
+test -f scripts/$2.ys
+
+rm -rf $1/work_$2
+mkdir $1/work_$2
+cd $1/work_$2
+
+yosys -ql yosys.log ../../scripts/$2.ys
+if [ "$1" = "synth_ecp5" ]; then
+    iverilog -o testbench  ../testbench.v synth.v ../../common.v ../../../../../techlibs/common/simcells.v ../../../../../techlibs/ecp5/cells_sim.v
+elif [ "$1" = "synth_achronix" ]; then
+    iverilog -o testbench  ../testbench.v synth.v ../../common.v ../../../../../techlibs/common/simcells.v ../../../../../techlibs/achronix/speedster22i/cells_sim.v
+elif [ "$1" = "synth_coolrunner2" ]; then
+    iverilog -o testbench  ../testbench.v synth.v ../../common.v ../../../../../techlibs/common/simcells.v ../../../../../techlibs/coolrunner2/cells_sim.v
+elif [ "$1" = "synth_gowin" ]; then
+    iverilog -o testbench  ../testbench.v synth.v ../../common.v ../../../../../techlibs/common/simcells.v ../../../../../techlibs/gowin/cells_sim.v
+elif [ "$1" = "synth_ice40" ]; then
+    iverilog -o testbench  ../testbench.v synth.v ../../common.v ../../../../../techlibs/common/simcells.v ../../../../../techlibs/ice40/cells_sim.v
+elif [ "$1" = "synth_intel" ]; then
+    iverilog -o testbench  ../testbench.v synth.v ../../common.v ../../../../../techlibs/common/simcells.v ../../../../../techlibs/intel/max10/cells_sim.v
+elif [ "$1" = "synth_intel_a10gx" ]; then
+    iverilog -o testbench  ../testbench.v synth.v ../../common.v ../../../../../techlibs/common/simcells.v ../../../../../techlibs/intel/a10gx/cells_sim.v
+elif [ "$1" = "synth_intel_cycloneiv" ]; then
+    iverilog -o testbench  ../testbench.v synth.v ../../common.v ../../../../../techlibs/common/simcells.v ../../../../../techlibs/intel/cycloneiv/cells_sim.v
+elif [ "$1" = "synth_intel_cycloneive" ]; then
+    iverilog -o testbench  ../testbench.v synth.v ../../common.v ../../../../../techlibs/common/simcells.v ../../../../../techlibs/intel/cycloneive/cells_sim.v
+elif [ "$1" = "synth_intel_cyclone10" ]; then
+    iverilog -o testbench  ../testbench.v synth.v ../../common.v ../../../../../techlibs/common/simcells.v ../../../../../techlibs/intel/cyclone10/cells_sim.v
+elif [ "$1" = "synth_intel_cyclonev" ]; then
+    iverilog -o testbench  ../testbench.v synth.v ../../common.v ../../../../../techlibs/common/simcells.v ../../../../../techlibs/intel/cyclonev/cells_sim.v
+elif [ "$1" = "synth_sf2" ]; then
+    iverilog -o testbench  ../testbench.v synth.v ../../common.v ../../../../../techlibs/common/simcells.v ../../../../../techlibs/sf2/cells_sim.v
+elif [ "$1" = "synth_xilinx" ]; then
+    iverilog -o testbench  ../testbench.v synth.v ../../common.v ../../../../../techlibs/common/simcells.v ../../../../../techlibs/xilinx/cells_sim.v
+elif [ "$1" = "synth_greenpak4" ]; then
+    iverilog -o testbench  ../testbench.v synth.v ../../common.v ../../../../../techlibs/common/simcells.v ../../../../../techlibs/greenpak4/cells_sim_digital.v
+else 
+    iverilog -o testbench  ../testbench.v synth.v ../../common.v ../../../../../techlibs/common/simcells.v
+fi
+
+if ! vvp -N testbench > testbench.log 2>&1; then
+	grep 'ERROR' testbench.log
+	echo fail > ${1}_${2}.status
+elif grep 'ERROR' testbench.log || ! grep 'OKAY' testbench.log; then
+	echo fail > ${1}_${2}.status
+else
+	echo pass > ${1}_${2}.status
+fi
+
+touch .stamp

--- a/architecture/scripts/synth_achronix.ys
+++ b/architecture/scripts/synth_achronix.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_achronix
+write_verilog synth.v 

--- a/architecture/scripts/synth_achronix_noflatten.ys
+++ b/architecture/scripts/synth_achronix_noflatten.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_achronix -flatten
+write_verilog synth.v 

--- a/architecture/scripts/synth_achronix_retime.ys
+++ b/architecture/scripts/synth_achronix_retime.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_achronix -retime
+write_verilog synth.v 

--- a/architecture/scripts/synth_achronix_run.ys
+++ b/architecture/scripts/synth_achronix_run.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_achronix -run begin:vout
+write_verilog synth.v 

--- a/architecture/scripts/synth_achronix_top.ys
+++ b/architecture/scripts/synth_achronix_top.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_achronix -top top
+write_verilog synth.v 

--- a/architecture/scripts/synth_achronix_vout.ys
+++ b/architecture/scripts/synth_achronix_vout.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_achronix -vout vout.v
+write_verilog synth.v 

--- a/architecture/scripts/synth_coolrunner2.ys
+++ b/architecture/scripts/synth_coolrunner2.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_coolrunner2
+write_verilog synth.v 

--- a/architecture/scripts/synth_coolrunner2_noflatten.ys
+++ b/architecture/scripts/synth_coolrunner2_noflatten.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_coolrunner2 -noflatten
+write_verilog synth.v 

--- a/architecture/scripts/synth_coolrunner2_retime.ys
+++ b/architecture/scripts/synth_coolrunner2_retime.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_coolrunner2 -retime
+write_verilog synth.v 

--- a/architecture/scripts/synth_coolrunner2_run.ys
+++ b/architecture/scripts/synth_coolrunner2_run.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_coolrunner2 -run begin:json
+write_verilog synth.v 

--- a/architecture/scripts/synth_coolrunner2_top.ys
+++ b/architecture/scripts/synth_coolrunner2_top.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_coolrunner2 -top top
+write_verilog synth.v 

--- a/architecture/scripts/synth_coolrunner2_vlog.ys
+++ b/architecture/scripts/synth_coolrunner2_vlog.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_easic -vlog vlog.v
+write_verilog synth.v 

--- a/architecture/scripts/synth_coolrunner2_vout.ys
+++ b/architecture/scripts/synth_coolrunner2_vout.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_coolrunner2 -json json.json
+write_verilog synth.v 

--- a/architecture/scripts/synth_easic.ys
+++ b/architecture/scripts/synth_easic.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_easic
+write_verilog synth.v 

--- a/architecture/scripts/synth_easic_etools.ys
+++ b/architecture/scripts/synth_easic_etools.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_easic -etools
+write_verilog synth.v 

--- a/architecture/scripts/synth_easic_noflatten.ys
+++ b/architecture/scripts/synth_easic_noflatten.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_easic -noflatten
+write_verilog synth.v 

--- a/architecture/scripts/synth_easic_retime.ys
+++ b/architecture/scripts/synth_easic_retime.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_easic -retime
+write_verilog synth.v 

--- a/architecture/scripts/synth_easic_run.ys
+++ b/architecture/scripts/synth_easic_run.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_easic -run begin:vlog
+write_verilog synth.v 

--- a/architecture/scripts/synth_easic_top.ys
+++ b/architecture/scripts/synth_easic_top.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_easic -top top
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5.ys
+++ b/architecture/scripts/synth_ecp5.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5_abc2.ys
+++ b/architecture/scripts/synth_ecp5_abc2.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -abc2
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5_blif.ys
+++ b/architecture/scripts/synth_ecp5_blif.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -blif blif.blif
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5_edif.ys
+++ b/architecture/scripts/synth_ecp5_edif.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -edif edif.edif
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5_flatten.ys
+++ b/architecture/scripts/synth_ecp5_flatten.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -flatten
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5_json.ys
+++ b/architecture/scripts/synth_ecp5_json.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -json json.json
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5_nobram.ys
+++ b/architecture/scripts/synth_ecp5_nobram.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -nobram
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5_noccu2.ys
+++ b/architecture/scripts/synth_ecp5_noccu2.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -noccu2
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5_nodffe.ys
+++ b/architecture/scripts/synth_ecp5_nodffe.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -nodffe
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5_nodram.ys
+++ b/architecture/scripts/synth_ecp5_nodram.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -nodram
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5_noflatten.ys
+++ b/architecture/scripts/synth_ecp5_noflatten.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -noflatten
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5_nomux.ys
+++ b/architecture/scripts/synth_ecp5_nomux.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -nomux
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5_retime.ys
+++ b/architecture/scripts/synth_ecp5_retime.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -retime
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5_run.ys
+++ b/architecture/scripts/synth_ecp5_run.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -run begin:json
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5_top.ys
+++ b/architecture/scripts/synth_ecp5_top.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -top top
+write_verilog synth.v 

--- a/architecture/scripts/synth_ecp5_vpr.ys
+++ b/architecture/scripts/synth_ecp5_vpr.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -vpr
+write_verilog synth.v 

--- a/architecture/scripts/synth_gowin.ys
+++ b/architecture/scripts/synth_gowin.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_gowin
+write_verilog synth.v 

--- a/architecture/scripts/synth_gowin_retime.ys
+++ b/architecture/scripts/synth_gowin_retime.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_gowin -retime
+write_verilog synth.v 

--- a/architecture/scripts/synth_gowin_run.ys
+++ b/architecture/scripts/synth_gowin_run.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_gowin -run begin:vout
+write_verilog synth.v 

--- a/architecture/scripts/synth_gowin_top.ys
+++ b/architecture/scripts/synth_gowin_top.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_gowin -top top
+write_verilog synth.v 

--- a/architecture/scripts/synth_gowin_vout.ys
+++ b/architecture/scripts/synth_gowin_vout.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_gowin -vout vout.v
+write_verilog synth.v 

--- a/architecture/scripts/synth_greenpak4.ys
+++ b/architecture/scripts/synth_greenpak4.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_greenpak4
+write_verilog synth.v 

--- a/architecture/scripts/synth_greenpak4_json.ys
+++ b/architecture/scripts/synth_greenpak4_json.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_greenpak4 -json json.json
+write_verilog synth.v 

--- a/architecture/scripts/synth_greenpak4_noflatten.ys
+++ b/architecture/scripts/synth_greenpak4_noflatten.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_greenpak4 -noflatten
+write_verilog synth.v 

--- a/architecture/scripts/synth_greenpak4_part140.ys
+++ b/architecture/scripts/synth_greenpak4_part140.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_greenpak4 -part SLG46140V
+write_verilog synth.v 

--- a/architecture/scripts/synth_greenpak4_part620.ys
+++ b/architecture/scripts/synth_greenpak4_part620.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_greenpak4 -part SLG46620V
+write_verilog synth.v 

--- a/architecture/scripts/synth_greenpak4_part621.ys
+++ b/architecture/scripts/synth_greenpak4_part621.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_greenpak4 -part SLG46621V
+write_verilog synth.v 

--- a/architecture/scripts/synth_greenpak4_retime.ys
+++ b/architecture/scripts/synth_greenpak4_retime.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_greenpak4 -retime
+write_verilog synth.v 

--- a/architecture/scripts/synth_greenpak4_run.ys
+++ b/architecture/scripts/synth_greenpak4_run.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_greenpak4 -run begin:json
+write_verilog synth.v 

--- a/architecture/scripts/synth_greenpak4_top.ys
+++ b/architecture/scripts/synth_greenpak4_top.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_greenpak4 -top top
+write_verilog synth.v 

--- a/architecture/scripts/synth_ice40.ys
+++ b/architecture/scripts/synth_ice40.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ice40
+write_verilog synth.v 

--- a/architecture/scripts/synth_ice40_abc2.ys
+++ b/architecture/scripts/synth_ice40_abc2.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ice40 -abc2
+write_verilog synth.v 

--- a/architecture/scripts/synth_ice40_blif.ys
+++ b/architecture/scripts/synth_ice40_blif.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ice40 -blif blif.blif
+write_verilog synth.v 

--- a/architecture/scripts/synth_ice40_edif.ys
+++ b/architecture/scripts/synth_ice40_edif.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ice40 -edif edif.edif
+write_verilog synth.v 

--- a/architecture/scripts/synth_ice40_flatten.ys
+++ b/architecture/scripts/synth_ice40_flatten.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ice40 -flatten
+write_verilog synth.v 

--- a/architecture/scripts/synth_ice40_json.ys
+++ b/architecture/scripts/synth_ice40_json.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ice40 -json json.json
+write_verilog synth.v 

--- a/architecture/scripts/synth_ice40_nobram.ys
+++ b/architecture/scripts/synth_ice40_nobram.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ice40 -nobram
+write_verilog synth.v 

--- a/architecture/scripts/synth_ice40_nocarry.ys
+++ b/architecture/scripts/synth_ice40_nocarry.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ice40 -nocarry
+write_verilog synth.v 

--- a/architecture/scripts/synth_ice40_nodffe.ys
+++ b/architecture/scripts/synth_ice40_nodffe.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ice40 -nodffe
+write_verilog synth.v 

--- a/architecture/scripts/synth_ice40_noflatten.ys
+++ b/architecture/scripts/synth_ice40_noflatten.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ice40 -noflatten
+write_verilog synth.v 

--- a/architecture/scripts/synth_ice40_retime.ys
+++ b/architecture/scripts/synth_ice40_retime.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ice40 -retime
+write_verilog synth.v 

--- a/architecture/scripts/synth_ice40_run.ys
+++ b/architecture/scripts/synth_ice40_run.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ice40 -run begin:json
+write_verilog synth.v 

--- a/architecture/scripts/synth_ice40_top.ys
+++ b/architecture/scripts/synth_ice40_top.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ice40 -top top
+write_verilog synth.v 

--- a/architecture/scripts/synth_ice40_vpr.ys
+++ b/architecture/scripts/synth_ice40_vpr.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ice40 -vpr
+write_verilog synth.v 

--- a/architecture/scripts/synth_intel.ys
+++ b/architecture/scripts/synth_intel.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_intel
+write_verilog synth.v 

--- a/architecture/scripts/synth_intel_a10gx.ys
+++ b/architecture/scripts/synth_intel_a10gx.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_intel -family a10gx
+write_verilog synth.v 

--- a/architecture/scripts/synth_intel_cyclone10.ys
+++ b/architecture/scripts/synth_intel_cyclone10.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_intel -family cyclone10
+write_verilog synth.v 

--- a/architecture/scripts/synth_intel_cycloneiv.ys
+++ b/architecture/scripts/synth_intel_cycloneiv.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_intel -family cycloneiv
+write_verilog synth.v 

--- a/architecture/scripts/synth_intel_cycloneive.ys
+++ b/architecture/scripts/synth_intel_cycloneive.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_intel -family cycloneive
+write_verilog synth.v 

--- a/architecture/scripts/synth_intel_cyclonev.ys
+++ b/architecture/scripts/synth_intel_cyclonev.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_intel -family cyclonev
+write_verilog synth.v 

--- a/architecture/scripts/synth_intel_max10.ys
+++ b/architecture/scripts/synth_intel_max10.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_intel -family max10
+write_verilog synth.v 

--- a/architecture/scripts/synth_intel_nobram.ys
+++ b/architecture/scripts/synth_intel_nobram.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_intel -nobram
+write_verilog synth.v 

--- a/architecture/scripts/synth_intel_noflatten.ys
+++ b/architecture/scripts/synth_intel_noflatten.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_intel -flatten
+write_verilog synth.v 

--- a/architecture/scripts/synth_intel_noiopads.ys
+++ b/architecture/scripts/synth_intel_noiopads.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_intel -noiopads
+write_verilog synth.v 

--- a/architecture/scripts/synth_intel_retime.ys
+++ b/architecture/scripts/synth_intel_retime.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_intel -retime
+write_verilog synth.v 

--- a/architecture/scripts/synth_intel_run.ys
+++ b/architecture/scripts/synth_intel_run.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_intel -run family:vpr
+write_verilog synth.v 

--- a/architecture/scripts/synth_intel_top.ys
+++ b/architecture/scripts/synth_intel_top.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_intel -top top
+write_verilog synth.v 

--- a/architecture/scripts/synth_intel_vpr.ys
+++ b/architecture/scripts/synth_intel_vpr.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_intel -vpr vpr.vpr
+write_verilog synth.v 

--- a/architecture/scripts/synth_intel_vqm.ys
+++ b/architecture/scripts/synth_intel_vqm.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_intel -vqm vqm.vqm
+write_verilog synth.v 

--- a/architecture/scripts/synth_sf2.ys
+++ b/architecture/scripts/synth_sf2.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_sf2
+write_verilog synth.v 

--- a/architecture/scripts/synth_sf2_edif.ys
+++ b/architecture/scripts/synth_sf2_edif.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_sf2 -edif edif.edif
+write_verilog synth.v 

--- a/architecture/scripts/synth_sf2_json.ys
+++ b/architecture/scripts/synth_sf2_json.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_sf2 -json json.json
+write_verilog synth.v 

--- a/architecture/scripts/synth_sf2_noflatten.ys
+++ b/architecture/scripts/synth_sf2_noflatten.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_sf2 -noflatten
+write_verilog synth.v 

--- a/architecture/scripts/synth_sf2_retime.ys
+++ b/architecture/scripts/synth_sf2_retime.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_sf2 -retime
+write_verilog synth.v 

--- a/architecture/scripts/synth_sf2_run.ys
+++ b/architecture/scripts/synth_sf2_run.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_sf2 -run begin:json
+write_verilog synth.v 

--- a/architecture/scripts/synth_sf2_top.ys
+++ b/architecture/scripts/synth_sf2_top.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_sf2 -top top
+write_verilog synth.v 

--- a/architecture/scripts/synth_xilinx.ys
+++ b/architecture/scripts/synth_xilinx.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx
+write_verilog synth.v 

--- a/architecture/scripts/synth_xilinx_blif.ys
+++ b/architecture/scripts/synth_xilinx_blif.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx -blif blif.blif
+write_verilog synth.v 

--- a/architecture/scripts/synth_xilinx_edif.ys
+++ b/architecture/scripts/synth_xilinx_edif.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx -edif edif.edif
+write_verilog synth.v 

--- a/architecture/scripts/synth_xilinx_flatten.ys
+++ b/architecture/scripts/synth_xilinx_flatten.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx -flatten
+write_verilog synth.v 

--- a/architecture/scripts/synth_xilinx_retime.ys
+++ b/architecture/scripts/synth_xilinx_retime.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx -retime
+write_verilog synth.v 

--- a/architecture/scripts/synth_xilinx_run.ys
+++ b/architecture/scripts/synth_xilinx_run.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx -run begin:blif
+write_verilog synth.v 

--- a/architecture/scripts/synth_xilinx_top.ys
+++ b/architecture/scripts/synth_xilinx_top.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx -top top
+write_verilog synth.v 

--- a/architecture/scripts/synth_xilinx_vpr.ys
+++ b/architecture/scripts/synth_xilinx_vpr.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx -vpr
+write_verilog synth.v 

--- a/architecture/synth_achronix/testbench.v
+++ b/architecture/synth_achronix/testbench.v
@@ -1,0 +1,32 @@
+module testbench;
+    reg [2:0] in;
+
+	wire patt_out,out;
+	wire patt_carry_out,carryout;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 in = 0;
+        repeat (10000) begin
+            #5 in = in + 1;
+        end
+
+        $display("OKAY");
+    end
+
+    top uut (
+	.x(in[0]),
+	.y(in[1]),
+	.cin(in[2]),
+	.A(out),
+	.cout(carryout)
+	);
+	
+	assign {patt_carry_out,patt_out} =  in[2] + in[1] + in[0];
+
+	assert_comb out_test(.A(patt_out), .B(out));
+	assert_comb carry_test(.A(patt_carry_out), .B(carryout));
+
+endmodule

--- a/architecture/synth_achronix/top.v
+++ b/architecture/synth_achronix/top.v
@@ -1,0 +1,17 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output A,
+ output cout
+ );
+
+`ifndef BUG
+assign {cout,A} =  cin + y + x;
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule

--- a/architecture/synth_coolrunner2/testbench.v
+++ b/architecture/synth_coolrunner2/testbench.v
@@ -1,0 +1,77 @@
+module testbench;
+    reg clk;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 clk = 0;
+        repeat (10000) begin
+            #5 clk = 1;
+            #5 clk = 0;
+        end
+
+        $display("OKAY");    
+    end
+   
+    
+    reg [2:0] dinA = 0;
+    wire doutB,doutB1,doutB2,doutB3,doutB4;
+	reg dff,ndff,adff,adffn,dffe = 0;
+
+    top uut (
+        .clk (clk ),
+        .a (dinA[0] ),
+        .pre (dinA[1] ),
+        .clr (dinA[2] ),
+        .b (doutB ),
+        .b1 (doutB1 ),
+        .b2 (doutB2 ),
+        .b3 (doutB3 ),
+        .b4 (doutB4 )
+    );
+    
+    always @(posedge clk) begin
+    #3;
+    dinA <= dinA + 1;
+    end
+	
+	always @( posedge clk, posedge dinA[1], posedge dinA[2] )
+		if ( dinA[2] )
+			dff <= 1'b0;
+		else if ( dinA[1] )
+			dff <= 1'b1;
+		else
+            dff <= dinA[0];
+    
+    always @( negedge clk, negedge dinA[1], negedge dinA[2] )
+		if ( !dinA[2] )
+			ndff <= 1'b0;
+		else if ( !dinA[1] )
+			ndff <= 1'b1;
+		else
+            ndff <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+			adff <= 1'b0;
+		else
+            adff <= dinA[0];
+            
+    always @( posedge clk, negedge dinA[2] )
+		if ( !dinA[2] )
+			adffn <= 1'b0;
+		else
+            adffn <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+            dffe <= dinA[0];
+            
+	assert_dff dff_test(.clk(clk), .test(doutB), .pat(dff));
+    assert_dff ndff_test(.clk(clk), .test(doutB1), .pat(ndff));
+    assert_dff adff_test(.clk(clk), .test(doutB2), .pat(adff));    
+    assert_dff adffn_test(.clk(clk), .test(doutB3), .pat(adffn));
+    assert_dff dffe_test(.clk(clk), .test(doutB4), .pat(dffe));
+    
+endmodule

--- a/architecture/synth_coolrunner2/top.v
+++ b/architecture/synth_coolrunner2/top.v
@@ -1,0 +1,128 @@
+module adff
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module adffn
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module dffe
+    ( input d, clk, en, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge en )
+		if ( en )
+`ifndef BUG        
+			q <= d;
+`else        
+			q <= 1'b0;
+`endif
+endmodule
+
+module dffsr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge pre, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module ndffnsnr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( negedge clk, negedge pre, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( !pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module top (
+input clk,
+input clr,
+input pre,
+input a,
+output b,b1,b2,b3,b4
+);
+
+dffsr u_dffsr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b )
+    );
+    
+ndffnsnr u_ndffnsnr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b1 )
+    );
+    
+adff u_adff (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b2 )
+    );
+    
+adffn u_adffn (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b3 )
+    );
+    
+dffe u_dffe (
+        .clk (clk ),
+        .en (clr),
+        .d (a ),
+        .q (b4 )
+    );
+
+endmodule

--- a/architecture/synth_easic/testbench.v
+++ b/architecture/synth_easic/testbench.v
@@ -1,0 +1,77 @@
+module testbench;
+    reg clk;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 clk = 0;
+        repeat (10000) begin
+            #5 clk = 1;
+            #5 clk = 0;
+        end
+
+        $display("OKAY");    
+    end
+   
+    
+    reg [2:0] dinA = 0;
+    wire doutB,doutB1,doutB2,doutB3,doutB4;
+	reg dff,ndff,adff,adffn,dffe = 0;
+
+    top uut (
+        .clk (clk ),
+        .a (dinA[0] ),
+        .pre (dinA[1] ),
+        .clr (dinA[2] ),
+        .b (doutB ),
+        .b1 (doutB1 ),
+        .b2 (doutB2 ),
+        .b3 (doutB3 ),
+        .b4 (doutB4 )
+    );
+    
+    always @(posedge clk) begin
+    #3;
+    dinA <= dinA + 1;
+    end
+	
+	always @( posedge clk, posedge dinA[1], posedge dinA[2] )
+		if ( dinA[2] )
+			dff <= 1'b0;
+		else if ( dinA[1] )
+			dff <= 1'b1;
+		else
+            dff <= dinA[0];
+    
+    always @( negedge clk, negedge dinA[1], negedge dinA[2] )
+		if ( !dinA[2] )
+			ndff <= 1'b0;
+		else if ( !dinA[1] )
+			ndff <= 1'b1;
+		else
+            ndff <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+			adff <= 1'b0;
+		else
+            adff <= dinA[0];
+            
+    always @( posedge clk, negedge dinA[2] )
+		if ( !dinA[2] )
+			adffn <= 1'b0;
+		else
+            adffn <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+            dffe <= dinA[0];
+            
+	assert_dff dff_test(.clk(clk), .test(doutB), .pat(dff));
+    assert_dff ndff_test(.clk(clk), .test(doutB1), .pat(ndff));
+    assert_dff adff_test(.clk(clk), .test(doutB2), .pat(adff));    
+    assert_dff adffn_test(.clk(clk), .test(doutB3), .pat(adffn));
+    assert_dff dffe_test(.clk(clk), .test(doutB4), .pat(dffe));
+    
+endmodule

--- a/architecture/synth_easic/top.v
+++ b/architecture/synth_easic/top.v
@@ -1,0 +1,128 @@
+module adff
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module adffn
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module dffe
+    ( input d, clk, en, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge en )
+		if ( en )
+`ifndef BUG        
+			q <= d;
+`else        
+			q <= 1'b0;
+`endif
+endmodule
+
+module dffsr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge pre, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module ndffnsnr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( negedge clk, negedge pre, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( !pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module top (
+input clk,
+input clr,
+input pre,
+input a,
+output b,b1,b2,b3,b4
+);
+
+dffsr u_dffsr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b )
+    );
+    
+ndffnsnr u_ndffnsnr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b1 )
+    );
+    
+adff u_adff (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b2 )
+    );
+    
+adffn u_adffn (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b3 )
+    );
+    
+dffe u_dffe (
+        .clk (clk ),
+        .en (clr),
+        .d (a ),
+        .q (b4 )
+    );
+
+endmodule

--- a/architecture/synth_ecp5/testbench.v
+++ b/architecture/synth_ecp5/testbench.v
@@ -1,0 +1,77 @@
+module testbench;
+    reg clk;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 clk = 0;
+        repeat (10000) begin
+            #5 clk = 1;
+            #5 clk = 0;
+        end
+
+        $display("OKAY");    
+    end
+   
+    
+    reg [2:0] dinA = 0;
+    wire doutB,doutB1,doutB2,doutB3,doutB4;
+	reg dff,ndff,adff,adffn,dffe = 0;
+
+    top uut (
+        .clk (clk ),
+        .a (dinA[0] ),
+        .pre (dinA[1] ),
+        .clr (dinA[2] ),
+        .b (doutB ),
+        .b1 (doutB1 ),
+        .b2 (doutB2 ),
+        .b3 (doutB3 ),
+        .b4 (doutB4 )
+    );
+    
+    always @(posedge clk) begin
+    #3;
+    dinA <= dinA + 1;
+    end
+	
+	always @( posedge clk, posedge dinA[1], posedge dinA[2] )
+		if ( dinA[2] )
+			dff <= 1'b0;
+		else if ( dinA[1] )
+			dff <= 1'b1;
+		else
+            dff <= dinA[0];
+    
+    always @( negedge clk, negedge dinA[1], negedge dinA[2] )
+		if ( !dinA[2] )
+			ndff <= 1'b0;
+		else if ( !dinA[1] )
+			ndff <= 1'b1;
+		else
+            ndff <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+			adff <= 1'b0;
+		else
+            adff <= dinA[0];
+            
+    always @( posedge clk, negedge dinA[2] )
+		if ( !dinA[2] )
+			adffn <= 1'b0;
+		else
+            adffn <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+            dffe <= dinA[0];
+            
+	assert_dff dff_test(.clk(clk), .test(doutB), .pat(dff));
+    assert_dff ndff_test(.clk(clk), .test(doutB1), .pat(ndff));
+    assert_dff adff_test(.clk(clk), .test(doutB2), .pat(adff));    
+    assert_dff adffn_test(.clk(clk), .test(doutB3), .pat(adffn));
+    assert_dff dffe_test(.clk(clk), .test(doutB4), .pat(dffe));
+    
+endmodule

--- a/architecture/synth_ecp5/top.v
+++ b/architecture/synth_ecp5/top.v
@@ -1,0 +1,128 @@
+module adff
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module adffn
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module dffe
+    ( input d, clk, en, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge en )
+		if ( en )
+`ifndef BUG        
+			q <= d;
+`else        
+			q <= 1'b0;
+`endif
+endmodule
+
+module dffsr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge pre, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module ndffnsnr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( negedge clk, negedge pre, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( !pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module top (
+input clk,
+input clr,
+input pre,
+input a,
+output b,b1,b2,b3,b4
+);
+
+dffsr u_dffsr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b )
+    );
+    
+ndffnsnr u_ndffnsnr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b1 )
+    );
+    
+adff u_adff (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b2 )
+    );
+    
+adffn u_adffn (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b3 )
+    );
+    
+dffe u_dffe (
+        .clk (clk ),
+        .en (clr),
+        .d (a ),
+        .q (b4 )
+    );
+
+endmodule

--- a/architecture/synth_gowin/testbench.v
+++ b/architecture/synth_gowin/testbench.v
@@ -1,0 +1,32 @@
+module testbench;
+    reg [2:0] in;
+
+	wire patt_out,out;
+	wire patt_carry_out,carryout;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 in = 0;
+        repeat (10000) begin
+            #5 in = in + 1;
+        end
+
+        $display("OKAY");
+    end
+
+    top uut (
+	.x(in[0]),
+	.y(in[1]),
+	.cin(in[2]),
+	.A(out),
+	.cout(carryout)
+	);
+	
+	assign {patt_carry_out,patt_out} =  in[2] + in[1] + in[0];
+
+	assert_comb out_test(.A(patt_out), .B(out));
+	assert_comb carry_test(.A(patt_carry_out), .B(carryout));
+
+endmodule

--- a/architecture/synth_gowin/top.v
+++ b/architecture/synth_gowin/top.v
@@ -1,0 +1,17 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output A,
+ output cout
+ );
+
+`ifndef BUG
+assign {cout,A} =  cin + y + x;
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule

--- a/architecture/synth_greenpak4/testbench.v
+++ b/architecture/synth_greenpak4/testbench.v
@@ -1,0 +1,77 @@
+module testbench;
+    reg clk;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 clk = 0;
+        repeat (10000) begin
+            #5 clk = 1;
+            #5 clk = 0;
+        end
+
+        $display("OKAY");    
+    end
+   
+    
+    reg [2:0] dinA = 0;
+    wire doutB,doutB1,doutB2,doutB3,doutB4;
+	reg dff,ndff,adff,adffn,dffe = 0;
+
+    top uut (
+        .clk (clk ),
+        .a (dinA[0] ),
+        .pre (dinA[1] ),
+        .clr (dinA[2] ),
+        .b (doutB ),
+        .b1 (doutB1 ),
+        .b2 (doutB2 ),
+        .b3 (doutB3 ),
+        .b4 (doutB4 )
+    );
+    
+    always @(posedge clk) begin
+    #3;
+    dinA <= dinA + 1;
+    end
+	
+	always @( posedge clk, posedge dinA[1], posedge dinA[2] )
+		if ( dinA[2] )
+			dff <= 1'b0;
+		else if ( dinA[1] )
+			dff <= 1'b1;
+		else
+            dff <= dinA[0];
+    
+    always @( negedge clk, negedge dinA[1], negedge dinA[2] )
+		if ( !dinA[2] )
+			ndff <= 1'b0;
+		else if ( !dinA[1] )
+			ndff <= 1'b1;
+		else
+            ndff <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+			adff <= 1'b0;
+		else
+            adff <= dinA[0];
+            
+    always @( posedge clk, negedge dinA[2] )
+		if ( !dinA[2] )
+			adffn <= 1'b0;
+		else
+            adffn <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+            dffe <= dinA[0];
+            
+	assert_dff dff_test(.clk(clk), .test(doutB), .pat(dff));
+    assert_dff ndff_test(.clk(clk), .test(doutB1), .pat(ndff));
+    assert_dff adff_test(.clk(clk), .test(doutB2), .pat(adff));    
+    assert_dff adffn_test(.clk(clk), .test(doutB3), .pat(adffn));
+    assert_dff dffe_test(.clk(clk), .test(doutB4), .pat(dffe));
+    
+endmodule

--- a/architecture/synth_greenpak4/top.v
+++ b/architecture/synth_greenpak4/top.v
@@ -1,0 +1,128 @@
+module adff
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module adffn
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module dffe
+    ( input d, clk, en, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge en )
+		if ( en )
+`ifndef BUG        
+			q <= d;
+`else        
+			q <= 1'b0;
+`endif
+endmodule
+
+module dffsr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge pre, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module ndffnsnr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( negedge clk, negedge pre, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( !pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module top (
+input clk,
+input clr,
+input pre,
+input a,
+output b,b1,b2,b3,b4
+);
+
+dffsr u_dffsr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b )
+    );
+    
+ndffnsnr u_ndffnsnr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b1 )
+    );
+    
+adff u_adff (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b2 )
+    );
+    
+adffn u_adffn (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b3 )
+    );
+    
+dffe u_dffe (
+        .clk (clk ),
+        .en (clr),
+        .d (a ),
+        .q (b4 )
+    );
+
+endmodule

--- a/architecture/synth_ice40/testbench.v
+++ b/architecture/synth_ice40/testbench.v
@@ -1,0 +1,77 @@
+module testbench;
+    reg clk;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 clk = 0;
+        repeat (10000) begin
+            #5 clk = 1;
+            #5 clk = 0;
+        end
+
+        $display("OKAY");    
+    end
+   
+    
+    reg [2:0] dinA = 0;
+    wire doutB,doutB1,doutB2,doutB3,doutB4;
+	reg dff,ndff,adff,adffn,dffe = 0;
+
+    top uut (
+        .clk (clk ),
+        .a (dinA[0] ),
+        .pre (dinA[1] ),
+        .clr (dinA[2] ),
+        .b (doutB ),
+        .b1 (doutB1 ),
+        .b2 (doutB2 ),
+        .b3 (doutB3 ),
+        .b4 (doutB4 )
+    );
+    
+    always @(posedge clk) begin
+    #3;
+    dinA <= dinA + 1;
+    end
+	
+	always @( posedge clk, posedge dinA[1], posedge dinA[2] )
+		if ( dinA[2] )
+			dff <= 1'b0;
+		else if ( dinA[1] )
+			dff <= 1'b1;
+		else
+            dff <= dinA[0];
+    
+    always @( negedge clk, negedge dinA[1], negedge dinA[2] )
+		if ( !dinA[2] )
+			ndff <= 1'b0;
+		else if ( !dinA[1] )
+			ndff <= 1'b1;
+		else
+            ndff <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+			adff <= 1'b0;
+		else
+            adff <= dinA[0];
+            
+    always @( posedge clk, negedge dinA[2] )
+		if ( !dinA[2] )
+			adffn <= 1'b0;
+		else
+            adffn <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+            dffe <= dinA[0];
+            
+	assert_dff dff_test(.clk(clk), .test(doutB), .pat(dff));
+    assert_dff ndff_test(.clk(clk), .test(doutB1), .pat(ndff));
+    assert_dff adff_test(.clk(clk), .test(doutB2), .pat(adff));    
+    assert_dff adffn_test(.clk(clk), .test(doutB3), .pat(adffn));
+    assert_dff dffe_test(.clk(clk), .test(doutB4), .pat(dffe));
+    
+endmodule

--- a/architecture/synth_ice40/top.v
+++ b/architecture/synth_ice40/top.v
@@ -1,0 +1,128 @@
+module adff
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module adffn
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module dffe
+    ( input d, clk, en, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge en )
+		if ( en )
+`ifndef BUG        
+			q <= d;
+`else        
+			q <= 1'b0;
+`endif
+endmodule
+
+module dffsr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge pre, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module ndffnsnr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( negedge clk, negedge pre, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( !pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module top (
+input clk,
+input clr,
+input pre,
+input a,
+output b,b1,b2,b3,b4
+);
+
+dffsr u_dffsr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b )
+    );
+    
+ndffnsnr u_ndffnsnr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b1 )
+    );
+    
+adff u_adff (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b2 )
+    );
+    
+adffn u_adffn (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b3 )
+    );
+    
+dffe u_dffe (
+        .clk (clk ),
+        .en (clr),
+        .d (a ),
+        .q (b4 )
+    );
+
+endmodule

--- a/architecture/synth_intel/testbench.v
+++ b/architecture/synth_intel/testbench.v
@@ -1,0 +1,32 @@
+module testbench;
+    reg [2:0] in;
+
+	wire patt_out,out;
+	wire patt_carry_out,carryout;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 in = 0;
+        repeat (10000) begin
+            #5 in = in + 1;
+        end
+
+        $display("OKAY");
+    end
+
+    top uut (
+	.x(in[0]),
+	.y(in[1]),
+	.cin(in[2]),
+	.A(out),
+	.cout(carryout)
+	);
+	
+	assign {patt_carry_out,patt_out} =  in[2] + in[1] + in[0];
+
+	assert_comb out_test(.A(patt_out), .B(out));
+	assert_comb carry_test(.A(patt_carry_out), .B(carryout));
+
+endmodule

--- a/architecture/synth_intel/top.v
+++ b/architecture/synth_intel/top.v
@@ -1,0 +1,17 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output A,
+ output cout
+ );
+
+`ifndef BUG
+assign {cout,A} =  cin + y + x;
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule

--- a/architecture/synth_intel_a10gx/testbench.v
+++ b/architecture/synth_intel_a10gx/testbench.v
@@ -1,0 +1,32 @@
+module testbench;
+    reg [2:0] in;
+
+	wire patt_out,out;
+	wire patt_carry_out,carryout;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 in = 0;
+        repeat (10000) begin
+            #5 in = in + 1;
+        end
+
+        $display("OKAY");
+    end
+
+    top uut (
+	.x(in[0]),
+	.y(in[1]),
+	.cin(in[2]),
+	.A(out),
+	.cout(carryout)
+	);
+	
+	assign {patt_carry_out,patt_out} =  in[2] + in[1] + in[0];
+
+	assert_comb out_test(.A(patt_out), .B(out));
+	assert_comb carry_test(.A(patt_carry_out), .B(carryout));
+
+endmodule

--- a/architecture/synth_intel_a10gx/top.v
+++ b/architecture/synth_intel_a10gx/top.v
@@ -1,0 +1,17 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output A,
+ output cout
+ );
+
+`ifndef BUG
+assign {cout,A} =  cin + y + x;
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule

--- a/architecture/synth_intel_cyclone10/testbench.v
+++ b/architecture/synth_intel_cyclone10/testbench.v
@@ -1,0 +1,32 @@
+module testbench;
+    reg [2:0] in;
+
+	wire patt_out,out;
+	wire patt_carry_out,carryout;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 in = 0;
+        repeat (10000) begin
+            #5 in = in + 1;
+        end
+
+        $display("OKAY");
+    end
+
+    top uut (
+	.x(in[0]),
+	.y(in[1]),
+	.cin(in[2]),
+	.A(out),
+	.cout(carryout)
+	);
+	
+	assign {patt_carry_out,patt_out} =  in[2] + in[1] + in[0];
+
+	assert_comb out_test(.A(patt_out), .B(out));
+	assert_comb carry_test(.A(patt_carry_out), .B(carryout));
+
+endmodule

--- a/architecture/synth_intel_cyclone10/top.v
+++ b/architecture/synth_intel_cyclone10/top.v
@@ -1,0 +1,17 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output A,
+ output cout
+ );
+
+`ifndef BUG
+assign {cout,A} =  cin + y + x;
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule

--- a/architecture/synth_intel_cycloneiv/testbench.v
+++ b/architecture/synth_intel_cycloneiv/testbench.v
@@ -1,0 +1,32 @@
+module testbench;
+    reg [2:0] in;
+
+	wire patt_out,out;
+	wire patt_carry_out,carryout;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 in = 0;
+        repeat (10000) begin
+            #5 in = in + 1;
+        end
+
+        $display("OKAY");
+    end
+
+    top uut (
+	.x(in[0]),
+	.y(in[1]),
+	.cin(in[2]),
+	.A(out),
+	.cout(carryout)
+	);
+	
+	assign {patt_carry_out,patt_out} =  in[2] + in[1] + in[0];
+
+	assert_comb out_test(.A(patt_out), .B(out));
+	assert_comb carry_test(.A(patt_carry_out), .B(carryout));
+
+endmodule

--- a/architecture/synth_intel_cycloneiv/top.v
+++ b/architecture/synth_intel_cycloneiv/top.v
@@ -1,0 +1,17 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output A,
+ output cout
+ );
+
+`ifndef BUG
+assign {cout,A} =  cin + y + x;
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule

--- a/architecture/synth_intel_cycloneive/testbench.v
+++ b/architecture/synth_intel_cycloneive/testbench.v
@@ -1,0 +1,32 @@
+module testbench;
+    reg [2:0] in;
+
+	wire patt_out,out;
+	wire patt_carry_out,carryout;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 in = 0;
+        repeat (10000) begin
+            #5 in = in + 1;
+        end
+
+        $display("OKAY");
+    end
+
+    top uut (
+	.x(in[0]),
+	.y(in[1]),
+	.cin(in[2]),
+	.A(out),
+	.cout(carryout)
+	);
+	
+	assign {patt_carry_out,patt_out} =  in[2] + in[1] + in[0];
+
+	assert_comb out_test(.A(patt_out), .B(out));
+	assert_comb carry_test(.A(patt_carry_out), .B(carryout));
+
+endmodule

--- a/architecture/synth_intel_cycloneive/top.v
+++ b/architecture/synth_intel_cycloneive/top.v
@@ -1,0 +1,17 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output A,
+ output cout
+ );
+
+`ifndef BUG
+assign {cout,A} =  cin + y + x;
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule

--- a/architecture/synth_intel_cyclonev/testbench.v
+++ b/architecture/synth_intel_cyclonev/testbench.v
@@ -1,0 +1,32 @@
+module testbench;
+    reg [2:0] in;
+
+	wire patt_out,out;
+	wire patt_carry_out,carryout;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 in = 0;
+        repeat (10000) begin
+            #5 in = in + 1;
+        end
+
+        $display("OKAY");
+    end
+
+    top uut (
+	.x(in[0]),
+	.y(in[1]),
+	.cin(in[2]),
+	.A(out),
+	.cout(carryout)
+	);
+	
+	assign {patt_carry_out,patt_out} =  in[2] + in[1] + in[0];
+
+	assert_comb out_test(.A(patt_out), .B(out));
+	assert_comb carry_test(.A(patt_carry_out), .B(carryout));
+
+endmodule

--- a/architecture/synth_intel_cyclonev/top.v
+++ b/architecture/synth_intel_cyclonev/top.v
@@ -1,0 +1,17 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output A,
+ output cout
+ );
+
+`ifndef BUG
+assign {cout,A} =  cin + y + x;
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule

--- a/architecture/synth_sf2/testbench.v
+++ b/architecture/synth_sf2/testbench.v
@@ -1,0 +1,77 @@
+module testbench;
+    reg clk;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 clk = 0;
+        repeat (10000) begin
+            #5 clk = 1;
+            #5 clk = 0;
+        end
+
+        $display("OKAY");    
+    end
+   
+    
+    reg [2:0] dinA = 0;
+    wire doutB,doutB1,doutB2,doutB3,doutB4;
+	reg dff,ndff,adff,adffn,dffe = 0;
+
+    top uut (
+        .clk (clk ),
+        .a (dinA[0] ),
+        .pre (dinA[1] ),
+        .clr (dinA[2] ),
+        .b (doutB ),
+        .b1 (doutB1 ),
+        .b2 (doutB2 ),
+        .b3 (doutB3 ),
+        .b4 (doutB4 )
+    );
+    
+    always @(posedge clk) begin
+    #3;
+    dinA <= dinA + 1;
+    end
+	
+	always @( posedge clk, posedge dinA[1], posedge dinA[2] )
+		if ( dinA[2] )
+			dff <= 1'b0;
+		else if ( dinA[1] )
+			dff <= 1'b1;
+		else
+            dff <= dinA[0];
+    
+    always @( negedge clk, negedge dinA[1], negedge dinA[2] )
+		if ( !dinA[2] )
+			ndff <= 1'b0;
+		else if ( !dinA[1] )
+			ndff <= 1'b1;
+		else
+            ndff <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+			adff <= 1'b0;
+		else
+            adff <= dinA[0];
+            
+    always @( posedge clk, negedge dinA[2] )
+		if ( !dinA[2] )
+			adffn <= 1'b0;
+		else
+            adffn <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+            dffe <= dinA[0];
+            
+	assert_dff dff_test(.clk(clk), .test(doutB), .pat(dff));
+    assert_dff ndff_test(.clk(clk), .test(doutB1), .pat(ndff));
+    assert_dff adff_test(.clk(clk), .test(doutB2), .pat(adff));    
+    assert_dff adffn_test(.clk(clk), .test(doutB3), .pat(adffn));
+    assert_dff dffe_test(.clk(clk), .test(doutB4), .pat(dffe));
+    
+endmodule

--- a/architecture/synth_sf2/top.v
+++ b/architecture/synth_sf2/top.v
@@ -1,0 +1,128 @@
+module adff
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module adffn
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module dffe
+    ( input d, clk, en, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge en )
+		if ( en )
+`ifndef BUG        
+			q <= d;
+`else        
+			q <= 1'b0;
+`endif
+endmodule
+
+module dffsr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge pre, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module ndffnsnr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( negedge clk, negedge pre, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( !pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module top (
+input clk,
+input clr,
+input pre,
+input a,
+output b,b1,b2,b3,b4
+);
+
+dffsr u_dffsr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b )
+    );
+    
+ndffnsnr u_ndffnsnr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b1 )
+    );
+    
+adff u_adff (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b2 )
+    );
+    
+adffn u_adffn (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b3 )
+    );
+    
+dffe u_dffe (
+        .clk (clk ),
+        .en (clr),
+        .d (a ),
+        .q (b4 )
+    );
+
+endmodule

--- a/architecture/synth_xilinx/testbench.v
+++ b/architecture/synth_xilinx/testbench.v
@@ -1,0 +1,77 @@
+module testbench;
+    reg clk;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 clk = 0;
+        repeat (10000) begin
+            #5 clk = 1;
+            #5 clk = 0;
+        end
+
+        $display("OKAY");    
+    end
+   
+    
+    reg [2:0] dinA = 0;
+    wire doutB,doutB1,doutB2,doutB3,doutB4;
+	reg dff,ndff,adff,adffn,dffe = 0;
+
+    top uut (
+        .clk (clk ),
+        .a (dinA[0] ),
+        .pre (dinA[1] ),
+        .clr (dinA[2] ),
+        .b (doutB ),
+        .b1 (doutB1 ),
+        .b2 (doutB2 ),
+        .b3 (doutB3 ),
+        .b4 (doutB4 )
+    );
+    
+    always @(posedge clk) begin
+    #3;
+    dinA <= dinA + 1;
+    end
+	
+	always @( posedge clk, posedge dinA[1], posedge dinA[2] )
+		if ( dinA[2] )
+			dff <= 1'b0;
+		else if ( dinA[1] )
+			dff <= 1'b1;
+		else
+            dff <= dinA[0];
+    
+    always @( negedge clk, negedge dinA[1], negedge dinA[2] )
+		if ( !dinA[2] )
+			ndff <= 1'b0;
+		else if ( !dinA[1] )
+			ndff <= 1'b1;
+		else
+            ndff <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+			adff <= 1'b0;
+		else
+            adff <= dinA[0];
+            
+    always @( posedge clk, negedge dinA[2] )
+		if ( !dinA[2] )
+			adffn <= 1'b0;
+		else
+            adffn <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+            dffe <= dinA[0];
+            
+	assert_dff dff_test(.clk(clk), .test(doutB), .pat(dff));
+    assert_dff ndff_test(.clk(clk), .test(doutB1), .pat(ndff));
+    assert_dff adff_test(.clk(clk), .test(doutB2), .pat(adff));    
+    assert_dff adffn_test(.clk(clk), .test(doutB3), .pat(adffn));
+    assert_dff dffe_test(.clk(clk), .test(doutB4), .pat(dffe));
+    
+endmodule

--- a/architecture/synth_xilinx/top.v
+++ b/architecture/synth_xilinx/top.v
@@ -1,0 +1,128 @@
+module adff
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module adffn
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module dffe
+    ( input d, clk, en, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge en )
+		if ( en )
+`ifndef BUG        
+			q <= d;
+`else        
+			q <= 1'b0;
+`endif
+endmodule
+
+module dffsr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge pre, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module ndffnsnr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( negedge clk, negedge pre, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( !pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module top (
+input clk,
+input clr,
+input pre,
+input a,
+output b,b1,b2,b3,b4
+);
+
+dffsr u_dffsr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b )
+    );
+    
+ndffnsnr u_ndffnsnr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b1 )
+    );
+    
+adff u_adff (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b2 )
+    );
+    
+adffn u_adffn (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b3 )
+    );
+    
+dffe u_dffe (
+        .clk (clk ),
+        .en (clr),
+        .d (a ),
+        .q (b4 )
+    );
+
+endmodule

--- a/simple/memory/testbench.v
+++ b/simple/memory/testbench.v
@@ -1,0 +1,79 @@
+module testbench;
+    reg clk;
+
+    initial begin
+         $dumpfile("testbench.vcd");
+         $dumpvars(0, testbench);
+
+        #5 clk = 0;
+        repeat (10000) begin
+            #5 clk = 1;
+            #5 clk = 0;
+        end
+
+        $display("OKAY");    
+    end
+   
+    
+    reg [7:0] data_a = 0;
+	reg [7:0] data_b = 0;
+	reg [5:0] addr_a = 0;	
+	reg [5:0] addr_b = 0;
+    reg we_a = 0;
+	reg we_b = 1;	
+    reg re_a = 1;
+	reg re_b = 1;
+	wire [7:0] q_a,q_b;
+	reg mem_init = 0;
+
+    top uut (
+    .data_a(data_a),
+	.data_b(data_b),
+	.addr_a(addr_a),
+	.addr_b(addr_b),
+	.we_a(we_a), 
+	.we_b(we_b), 	
+	.re_a(re_a), 
+	.re_b(re_b), 
+	.clk(clk),
+	.q_a(q_a), 
+	.q_b(q_b)
+    );
+    
+    always @(posedge clk) begin
+    #3;
+    data_a <= data_a + 17;	
+    data_b <= data_b + 5;
+	
+    addr_a <= addr_a + 1;	
+    addr_b <= addr_b + 1;
+    end
+    
+    always @(posedge addr_a) begin
+    #10;
+        if(addr_a > 6'h3E)
+            mem_init <= 1;
+    end
+	
+	always @(posedge clk) begin
+    //#3;
+    we_a <= !we_a; 
+    we_b <= !we_b; 
+    end
+	
+	uut_mem_checker port_a_test(.clk(clk), .init(mem_init), .en(!we_a), .A(q_a));
+    uut_mem_checker port_b_test(.clk(clk), .init(mem_init), .en(!we_b), .A(q_b));
+    
+endmodule
+
+module uut_mem_checker(input clk, input init, input en, input [7:0] A);
+    always @(posedge clk)
+    begin
+        #1;
+        if (en == 1 & init == 1 & A === 8'bXXXXXXXX)
+        begin
+            $display("ERROR: ASSERTION FAILED in %m:",$time," ",A);
+            //$stop;
+        end
+    end
+endmodule

--- a/simple/memory/top.v
+++ b/simple/memory/top.v
@@ -1,0 +1,47 @@
+module top
+(
+	input [7:0] data_a, data_b,
+	input [6:1] addr_a, addr_b,
+	input we_a, we_b, re_a, re_b, clk,
+	output reg [7:0] q_a, q_b
+);
+	// Declare the RAM variable
+	reg [7:0] ram[63:0];
+	
+	// Port A
+	always @ (posedge clk)
+	begin
+`ifndef BUG        
+		if (we_a) 
+`else        
+		if (we_b) 
+`endif
+		begin
+			ram[addr_a] <= data_a;
+			q_a <= data_a;
+		end
+		if (re_b) 
+		begin
+			q_a <= ram[addr_a];
+		end
+	end
+	
+	// Port B
+	always @ (posedge clk)
+	begin
+`ifndef BUG        
+		if (we_b) 
+`else        
+		if (we_a) 
+`endif
+		begin
+			ram[addr_b] <= data_b;
+			q_b <= data_b;
+		end
+		if (re_b)
+		begin
+			q_b <= ram[addr_b];
+		end
+	end
+	
+endmodule								 


### PR DESCRIPTION
II architecture
============= 
Most of tests use synth to do actuall synthesis, since there are more of them supported by yosys
aim is to run some mid size example (for example use picosoc) and make it synth for all architectures.
Idea is to keep these tests in separate directory (so not in simple but one named architecture)
For running testbench with iverilog you can use cell cells_sim.v  from specific architecture where needed.

1. http://scratch.clifford.at/coverage_html/techlibs/achronix/index.html
2. http://scratch.clifford.at/coverage_html/techlibs/coolrunner2/index.html
3. http://scratch.clifford.at/coverage_html/techlibs/easic/index.html
4. http://scratch.clifford.at/coverage_html/techlibs/ecp5/synth_ecp5.cc.gcov.html
5. http://scratch.clifford.at/coverage_html/techlibs/gowin/index.html
6. http://scratch.clifford.at/coverage_html/techlibs/ice40/ice40_ffinit.cc.gcov.html
7. http://scratch.clifford.at/coverage_html/techlibs/intel/synth_intel.cc.gcov.html
8. http://scratch.clifford.at/coverage_html/techlibs/sf2/synth_sf2.cc.gcov.html
9. http://scratch.clifford.at/coverage_html/techlibs/xilinx/synth_xilinx.cc.gcov.html

Testing problems:
1. http://scratch.clifford.at/coverage_html/techlibs/achronix/index.html - in the code '-flatten' but in the help '-noflatten'
3. http://scratch.clifford.at/coverage_html/techlibs/easic/index.html -
etc/eTools is required
5. http://scratch.clifford.at/coverage_html/techlibs/gowin/index.html -
in the code '-flatten' but in the help '-noflatten'
5. http://scratch.clifford.at/coverage_html/techlibs/gowin/index.html -
for -family cyclonev: /techlibs/intel/cyclonev/cells_sim.v:88: error:
Unable to bind wire/reg/memory `upper_mask_value' in
`testbench.uut._05_.lut5'