### PR TITLE
Add new tests to 'simple' and 'misc' test groups

### DIFF
--- a/misc/Makefile
+++ b/misc/Makefile
@@ -48,7 +48,7 @@ $(eval $(call template,scc, scc scc_all_cell_types scc_expect scc_max_depth scc_
 $(eval $(call template,scatter, scatter ))
 
 #rename
-$(eval $(call template,rename, rename rename_top rename_src rename_hide rename_enumerate rename_enumerate_pat))
+$(eval $(call template,rename, rename rename_top rename_src rename_hide rename_enumerate rename_enumerate_pat rename_wire))
 
 #qwp
 #qwp_v - exception
@@ -71,5 +71,73 @@ $(eval $(call template,cover, cover cover_q cover_o cover_dir cover_a ))
 
 #insbuf ERROR: Found error in internal cell
 #$(eval $(call template,insbuf,insbuf insbuf_cell))
+
+#add
+$(eval $(call template,add, add add_wire add_input add_output add_inout add_global_input ))
+
+#blackbox
+$(eval $(call template,blackbox, blackbox ))
+
+#bugpoint ERROR: No such command: autoidx (type 'help' for a command overview)
+#$(eval $(call template,bugpoint, bugpoint bugpoint_yosys bugpoint_script bugpoint_grep bugpoint_fast bugpoint_clean bugpoint_modules bugpoint_ports bugpoint_cells bugpoint_connections  ))
+
+#chformal
+$(eval $(call template,chformal, chformal chformal_assert2assume chformal_assert chformal_assume2assert chformal_assume chformal_cover chformal_delay chformal_early chformal_proc_early chformal_fair2live_assert2assume chformal_fair2live chformal_fair chformal_live2fair chformal_live chformal_skip ))
+$(eval $(call template,chformal_dff, chformal chformal_assert2assume chformal_assert chformal_assume2assert chformal_assume chformal_cover chformal_delay chformal_early chformal_proc_early chformal_fair2live_assert2assume chformal_fair2live chformal_fair chformal_live2fair chformal_live chformal_skip ))
+
+#chtype
+$(eval $(call template,chtype, chtype chtype_map chtype_selection chtype_set))
+
+#connect
+#connect_nomap_port connect_port - ERROR: Can't find cell $2.
+$(eval $(call template,connect,  connect_nomap_set connect_nomap_unset connect_nounset_set connect_set connect_unset))
+
+#connwrappers
+$(eval $(call template,connwrappers, connwrappers connwrappers_signed connwrappers_unsigned connwrappers_port ))
+
+#plugin
+$(eval $(call template,plugin, plugin plugin_i plugin_a plugin_l ))
+
+#select
+$(eval $(call template,select, select select_all select_add select_add_all select_assert_any select_assert_count select_assert_max select_assert_min select_assert_none select_clear select_count select_del select_list select_module select_none select_read select_set select_write select_add_A_eq select_add_a_eq select_add_A_lesseq select_add_a_lesseq select_add_A_less select_add_a_less select_add_A_moreeq select_add_a_moreeq select_add_A_more select_add_a_more select_add_A select_add_a select_add_c select_add_i select_add_mid select_add_m select_add_n select_add_obj select_add_o select_add_p select_add_r_eq select_add_r_lesseq select_add_r_less select_add_r_moreeq select_add_r_more select_add_r select_add_ss select_add_s select_add_t select_add_w select_add_x ))
+$(eval $(call template,select_mem, select select_all select_add select_add_all select_assert_any select_assert_count_mem select_assert_max_mem select_assert_min select_assert_none select_clear select_count select_del select_list select_module_mem select_none select_read select_set select_write select_add_A_eq select_add_a_eq select_add_A_lesseq select_add_a_lesseq select_add_A_less select_add_a_less select_add_A_moreeq select_add_a_moreeq select_add_A_more select_add_a_more select_add_A select_add_a select_add_c select_add_i select_add_mid select_add_m select_add_n select_add_obj select_add_o select_add_p select_add_r_eq select_add_r_lesseq select_add_r_less select_add_r_moreeq select_add_r_more select_add_r select_add_ss select_add_s select_add_t select_add_w select_add_x ))
+$(eval $(call template,select_ls, select_ls select_ls_top))
+$(eval $(call template,select_cd, select_cd select_cd_up select_cd_module ))
+$(eval $(call template,select_stack,select_%a select_%cie select_%ci select_%coe select_%co select_%C select_%c select_%i select_%M select_%m select_%n select_%R4 select_%R select_%s select_%u select_%x_%D select_%x_%d select_%xe select_%))
+
+#setattr
+$(eval $(call template,setattr, setattr setattr_mod setattr_set setattr_top setattr_unset setattr_set_proc ))
+$(eval $(call template,setattr_mem, setattr setattr_mod setattr_set setattr_top setattr_unset setattr_set_proc ))
+#setparam
+#setparam_type
+#ERROR: Found error in internal cell \top.$procdff$4 ($dff) at kernel/rtlil.cc:715:
+$(eval $(call template,setparam, setparam setparam_set  setparam_unset setparam_top ))
+#chparam
+$(eval $(call template,chparam, chparam chparam_set chparam_top chparam_list ))
+
+#setundef
+$(eval $(call template,setundef, setundef_one setundef_anyseq setundef_anyconst setundef_init setundef_random setundef_undef setundef_undriven setundef_expose))
+
+#assertpmux
+$(eval $(call template,assertpmux, assertpmux assertpmux_noinit assertpmux_always))
+
+#eval
+$(eval $(call template,eval, eval eval_set eval_set_undef eval_table eval_show eval_brute_force_equiv_checker eval_show_not_set eval_table_set eval_vloghammer_report eval_vloghammer_report_rtl))
+
+#freduce
+$(eval $(call template,freduce, freduce freduce_v freduce_vv freduce_inv freduce_stop freduce_dump ))
+$(eval $(call template,freduce_dff, freduce freduce_v freduce_vv freduce_inv freduce_stop freduce_dump ))
+$(eval $(call template,freduce_mem, freduce freduce_v freduce_vv freduce_inv freduce_stop freduce_dump ))
+
+#miter -assert
+$(eval $(call template,miter_assert, miter_assert miter_assert_flatten ))
+$(eval $(call template,miter_assert_assume, miter_assert miter_assert_flatten ))
+
+#sat
+$(eval $(call template,sat, sat_dump_cnf sat_dump_json sat_dump_vcd sat_initsteps sat_maxsteps sat_max sat_prove_x sat_set_all_undef_at sat_set_all_undef sat_set_any_undef_at sat_set_any_undef sat_set_def_at sat_set_def sat_set_init sat_set sat_show sat_stepsize sat_tempinduct_skip sat_unset_at ))
+
+#sim
+$(eval $(call template,sim,sim sim_a sim_clock sim_d sim_n sim_rstlen sim_vcd sim_w sim_zinit ))
+$(eval $(call template,sim_mem,sim sim_a sim_clockn sim_clock_mem sim_d sim_n sim_resetn sim_reset sim_rstlen sim_vcd sim_w sim_zinit_mem ))
 
 .PHONY: all clean

--- a/misc/add/top.v
+++ b/misc/add/top.v
@@ -1,0 +1,17 @@
+(* black_box *) module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output A,
+ output cout
+ );
+
+`ifndef BUG
+assign {cout,A} =  cin + y + x;
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule

--- a/misc/assertpmux/top.v
+++ b/misc/assertpmux/top.v
@@ -1,0 +1,17 @@
+module top(C, S, Y);
+input C;
+input [1:0] S;
+output reg [3:0] Y;
+
+initial Y = 0;
+
+always @(posedge C) begin
+        case (S)
+                2'b00: Y <= 4'b0001;
+                2'b01: Y <= 4'b0010;
+                2'b10: Y <= 4'b0100;
+                2'b11: Y <= 4'b1000;
+        endcase
+end
+
+endmodule

--- a/misc/blackbox/top.v
+++ b/misc/blackbox/top.v
@@ -1,0 +1,31 @@
+module bb
+(
+ input x,
+ input y,
+ input cin,
+
+ output A,
+ output cout
+ );
+
+`ifndef BUG
+assign {cout,A} =  cin + y + x;
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output A,
+ output cout
+ );
+
+bb u_bb (x,y,cin,A,cout);
+
+endmodule

--- a/misc/bugpoint/top.v
+++ b/misc/bugpoint/top.v
@@ -1,0 +1,31 @@
+module bb
+(
+ input x,
+ input y,
+ input cin,
+
+ output A,
+ output cout
+ );
+
+`ifndef BUG
+assign {cout,A} =  cin + y + x;
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output A,
+ output cout
+ );
+
+bb u_bb (x,y,cin,A,cout);
+
+endmodule

--- a/misc/chformal/top.v
+++ b/misc/chformal/top.v
@@ -1,0 +1,43 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output reg A,
+ output reg cout
+ );
+
+ reg ASSERT = 1;
+ (* anyconst *) reg foo;
+ (* anyseq *) reg too;
+
+
+
+ initial begin
+    begin
+        A = 0;
+        cout = 0;
+    end
+ end
+
+`ifndef BUG
+always @(posedge x) begin
+    if ($initstate)
+        A <= 0;
+    A <=  y + cin + too;
+    assume(too);
+    assume(s_eventually too);
+end
+always @(negedge x) begin
+    if ($initstate)
+        cout <= 0;
+        cout <=  y + A + foo;
+    assert(ASSERT);
+    assert(s_eventually ASSERT);
+end
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule

--- a/misc/chformal_dff/top.v
+++ b/misc/chformal_dff/top.v
@@ -1,0 +1,5 @@
+module top
+    ( input d, clk, output reg q );
+	always @( posedge clk )
+            q <= d;
+endmodule

--- a/misc/chparam/top.v
+++ b/misc/chparam/top.v
@@ -1,0 +1,34 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output reg A,
+ output cout
+ );
+ wire o;
+ parameter X = 1;
+
+`ifndef BUG
+always @(posedge cin)
+	A <= o;
+
+assign cout =  cin? y : x;
+
+middle u_mid (x,y,o);
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module middle
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule

--- a/misc/chtype/top.v
+++ b/misc/chtype/top.v
@@ -1,0 +1,5 @@
+module top
+    ( input d, clk, output reg q );
+	always @( posedge clk )
+            q <= d;
+endmodule

--- a/misc/connect/top.v
+++ b/misc/connect/top.v
@@ -1,0 +1,5 @@
+module top
+    ( input d, clk, output reg q );
+	always @( posedge clk )
+            q <= d;
+endmodule

--- a/misc/connwrappers/top.v
+++ b/misc/connwrappers/top.v
@@ -1,0 +1,5 @@
+module top
+    ( input d, clk, output reg q );
+	always @( posedge clk )
+            q <= d;
+endmodule

--- a/misc/eval/top.v
+++ b/misc/eval/top.v
@@ -1,0 +1,45 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output reg A,
+ output cout
+ );
+ parameter X = 1;
+ wire o;
+
+`ifndef BUG
+always @(posedge cin)
+	A <= o;
+
+assign cout =  cin? y : x;
+
+middle u_mid (.x(x),.o(o),.y(1'b0));
+u_rtl inst_u_rtl (.x(x),.o(o));
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module middle
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule
+
+module u_rtl
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule

--- a/misc/freduce/top.v
+++ b/misc/freduce/top.v
@@ -1,0 +1,45 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output reg A,
+ output cout
+ );
+ parameter X = 1;
+ wire o;
+
+`ifndef BUG
+always @(posedge cin)
+	A <= o;
+
+//assign cout =  cin? y : x;
+
+middle u_mid (.x(x),.o(o));
+u_rtl inst_u_rtl (.x(x),.o(o));
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module middle
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule
+
+module u_rtl
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule

--- a/misc/freduce_dff/top.v
+++ b/misc/freduce_dff/top.v
@@ -1,0 +1,5 @@
+module top
+    ( input d, clk, output reg q );
+	always @( posedge clk )
+            q <= d;
+endmodule

--- a/misc/freduce_mem/top.v
+++ b/misc/freduce_mem/top.v
@@ -1,0 +1,52 @@
+module top
+(
+	input [7:0] data_a, data_b,
+	input [6:1] addr_a, addr_b,
+	input we_a, we_b, re_a, re_b, clka, clkb,
+	output reg [7:0] q_a, q_b
+);
+	// Declare the RAM variable
+	reg [7:0] ram[63:0];
+	
+	initial begin
+        q_a <= 8'h00;        
+        q_b <= 8'd0;
+	end
+	
+	// Port A
+	always @ (posedge clka)
+	begin
+`ifndef BUG        
+		if (we_a) 
+`else        
+		if (we_b) 
+`endif
+		begin
+			ram[addr_a] <= data_a;
+			q_a <= data_a;
+		end
+		if (re_b) 
+		begin
+			q_a <= ram[addr_a];
+		end
+	end
+	
+	// Port B
+	always @ (posedge clkb)
+	begin
+`ifndef BUG        
+		if (we_b) 
+`else        
+		if (we_a) 
+`endif
+		begin
+			ram[addr_b] <= data_b;
+			q_b <= data_b;
+		end
+		if (re_b)
+		begin
+			q_b <= ram[addr_b];
+		end
+	end
+	
+endmodule								 

--- a/misc/miter_assert/top.v
+++ b/misc/miter_assert/top.v
@@ -1,0 +1,45 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output reg A,
+ output cout
+ );
+ parameter X = 1;
+ wire o;
+
+`ifndef BUG
+always @(posedge cin)
+	A <= o;
+
+//assign cout =  cin? y : x;
+
+middle u_mid (.x(x),.o(o));
+u_rtl inst_u_rtl (.x(x),.o(o));
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module middle
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule
+
+module u_rtl
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule

--- a/misc/miter_assert_assume/top.v
+++ b/misc/miter_assert_assume/top.v
@@ -1,0 +1,53 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output reg A,
+ output reg cout
+ );
+
+ reg ASSERT = 1;
+ (* anyconst *) reg foo;
+ (* anyseq *) reg too;
+
+
+
+ initial begin
+    begin
+        A = 0;
+        cout = 0;
+    end
+ end
+
+`ifndef BUG
+always @(posedge x) begin
+    if ($initstate)
+        A <= 0;
+    A <=  y + cin + too;
+    assume(too);
+    assume(s_eventually too);
+end
+always @(negedge x) begin
+    if ($initstate)
+        cout <= 0;
+        cout <=  y + A + foo;
+    assert(ASSERT);
+    assert(s_eventually ASSERT);
+end
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module middle
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule

--- a/misc/plugin/top.v
+++ b/misc/plugin/top.v
@@ -1,0 +1,5 @@
+module top
+    ( input d, clk, output reg q );
+	always @( posedge clk )
+            q <= d;
+endmodule

--- a/misc/sat/top.v
+++ b/misc/sat/top.v
@@ -1,0 +1,45 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output reg A,
+ output cout
+ );
+ parameter X = 1;
+ wire o;
+
+`ifndef BUG
+always @(posedge cin)
+	A <= o;
+
+//assign cout =  cin? y : x;
+
+middle u_mid (.x(x),.o(o));
+u_rtl inst_u_rtl (.x(x),.o(o));
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module middle
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule
+
+module u_rtl
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule

--- a/misc/scripts/add.ys
+++ b/misc/scripts/add.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log add -wire w 0

--- a/misc/scripts/add_global_input.ys
+++ b/misc/scripts/add_global_input.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log add -global_input gi 32000

--- a/misc/scripts/add_inout.ys
+++ b/misc/scripts/add_inout.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log add -inout \34 3

--- a/misc/scripts/add_input.ys
+++ b/misc/scripts/add_input.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+add -input i 2
+tee -o result.log add -input i 2

--- a/misc/scripts/add_output.ys
+++ b/misc/scripts/add_output.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log add -output o 3

--- a/misc/scripts/add_wire.ys
+++ b/misc/scripts/add_wire.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log add -wire w 1

--- a/misc/scripts/assertpmux.ys
+++ b/misc/scripts/assertpmux.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log assertpmux

--- a/misc/scripts/assertpmux_always.ys
+++ b/misc/scripts/assertpmux_always.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log assertpmux -always

--- a/misc/scripts/assertpmux_noinit.ys
+++ b/misc/scripts/assertpmux_noinit.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log assertpmux -noinit

--- a/misc/scripts/blackbox.ys
+++ b/misc/scripts/blackbox.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log blackbox bb

--- a/misc/scripts/bugpoint.ys
+++ b/misc/scripts/bugpoint.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log bugpoint

--- a/misc/scripts/bugpoint_cells.ys
+++ b/misc/scripts/bugpoint_cells.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log bugpoint -cells

--- a/misc/scripts/bugpoint_clean.ys
+++ b/misc/scripts/bugpoint_clean.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log bugpoint -clean

--- a/misc/scripts/bugpoint_connections.ys
+++ b/misc/scripts/bugpoint_connections.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log bugpoint -connections

--- a/misc/scripts/bugpoint_fast.ys
+++ b/misc/scripts/bugpoint_fast.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log bugpoint -fast

--- a/misc/scripts/bugpoint_grep.ys
+++ b/misc/scripts/bugpoint_grep.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log bugpoint -grep "Yosys"

--- a/misc/scripts/bugpoint_modules.ys
+++ b/misc/scripts/bugpoint_modules.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log bugpoint -modules

--- a/misc/scripts/bugpoint_ports.ys
+++ b/misc/scripts/bugpoint_ports.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log bugpoint -ports

--- a/misc/scripts/bugpoint_script.ys
+++ b/misc/scripts/bugpoint_script.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log bugpoint -script script.ys

--- a/misc/scripts/bugpoint_yosys.ys
+++ b/misc/scripts/bugpoint_yosys.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log bugpoint -yosys yosys.ys

--- a/misc/scripts/chformal.ys
+++ b/misc/scripts/chformal.ys
@@ -1,0 +1,2 @@
+read_verilog -sv ../top.v
+tee -o result.log chformal -remove

--- a/misc/scripts/chformal_assert.ys
+++ b/misc/scripts/chformal_assert.ys
@@ -1,0 +1,2 @@
+read_verilog -sv ../top.v
+tee -o result.log chformal -assert -remove

--- a/misc/scripts/chformal_assert2assume.ys
+++ b/misc/scripts/chformal_assert2assume.ys
@@ -1,0 +1,2 @@
+read_verilog -sv ../top.v
+tee -o result.log chformal -assert2assume

--- a/misc/scripts/chformal_assume.ys
+++ b/misc/scripts/chformal_assume.ys
@@ -1,0 +1,2 @@
+read_verilog -sv ../top.v
+tee -o result.log chformal -assume -remove

--- a/misc/scripts/chformal_assume2assert.ys
+++ b/misc/scripts/chformal_assume2assert.ys
@@ -1,0 +1,2 @@
+read_verilog -sv ../top.v
+tee -o result.log chformal -assume2assert

--- a/misc/scripts/chformal_cover.ys
+++ b/misc/scripts/chformal_cover.ys
@@ -1,0 +1,2 @@
+read_verilog -sv ../top.v
+tee -o result.log chformal -cover -remove

--- a/misc/scripts/chformal_delay.ys
+++ b/misc/scripts/chformal_delay.ys
@@ -1,0 +1,2 @@
+read_verilog -sv ../top.v
+tee -o result.log chformal -delay 2

--- a/misc/scripts/chformal_early.ys
+++ b/misc/scripts/chformal_early.ys
@@ -1,0 +1,2 @@
+read_verilog -sv ../top.v
+tee -o result.log chformal -early

--- a/misc/scripts/chformal_fair.ys
+++ b/misc/scripts/chformal_fair.ys
@@ -1,0 +1,2 @@
+read_verilog -sv ../top.v
+tee -o result.log chformal -fair -remove

--- a/misc/scripts/chformal_fair2live.ys
+++ b/misc/scripts/chformal_fair2live.ys
@@ -1,0 +1,2 @@
+read_verilog -sv ../top.v
+tee -o result.log chformal -fair2live

--- a/misc/scripts/chformal_fair2live_assert2assume.ys
+++ b/misc/scripts/chformal_fair2live_assert2assume.ys
@@ -1,0 +1,2 @@
+read_verilog -sv ../top.v
+tee -o result.log chformal -fair2live -assert2assume

--- a/misc/scripts/chformal_live.ys
+++ b/misc/scripts/chformal_live.ys
@@ -1,0 +1,2 @@
+read_verilog -sv ../top.v
+tee -o result.log chformal -live -remove

--- a/misc/scripts/chformal_live2fair.ys
+++ b/misc/scripts/chformal_live2fair.ys
@@ -1,0 +1,2 @@
+read_verilog -sv ../top.v
+tee -o result.log chformal -live2fair

--- a/misc/scripts/chformal_proc_early.ys
+++ b/misc/scripts/chformal_proc_early.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log chformal -early

--- a/misc/scripts/chformal_skip.ys
+++ b/misc/scripts/chformal_skip.ys
@@ -1,0 +1,2 @@
+read_verilog -sv ../top.v
+tee -o result.log chformal -skip 2

--- a/misc/scripts/chparam.ys
+++ b/misc/scripts/chparam.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log chparam

--- a/misc/scripts/chparam_list.ys
+++ b/misc/scripts/chparam_list.ys
@@ -1,0 +1,5 @@
+read_verilog ../top.v
+proc
+tee -o result.log chparam -set X 2 top
+tee -o result.log chparam -list
+

--- a/misc/scripts/chparam_set.ys
+++ b/misc/scripts/chparam_set.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log chparam -set X 2 top

--- a/misc/scripts/chparam_top.ys
+++ b/misc/scripts/chparam_top.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log chparam top

--- a/misc/scripts/chtype.ys
+++ b/misc/scripts/chtype.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log chtype

--- a/misc/scripts/chtype_map.ys
+++ b/misc/scripts/chtype_map.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log chtype -map $dff $adff $2

--- a/misc/scripts/chtype_selection.ys
+++ b/misc/scripts/chtype_selection.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log chtype $2

--- a/misc/scripts/chtype_set.ys
+++ b/misc/scripts/chtype_set.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log chtype -set $adff $2

--- a/misc/scripts/connect_nomap_port.ys
+++ b/misc/scripts/connect_nomap_port.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log connect -nomap -port $dff d q

--- a/misc/scripts/connect_nomap_set.ys
+++ b/misc/scripts/connect_nomap_set.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log connect -nomap -set d q

--- a/misc/scripts/connect_nomap_unset.ys
+++ b/misc/scripts/connect_nomap_unset.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log connect -nomap -unset d q

--- a/misc/scripts/connect_nounset_set.ys
+++ b/misc/scripts/connect_nounset_set.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log connect -nounset -set d q

--- a/misc/scripts/connect_port.ys
+++ b/misc/scripts/connect_port.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log connect -port $2 d q

--- a/misc/scripts/connect_set.ys
+++ b/misc/scripts/connect_set.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log connect -set d q

--- a/misc/scripts/connect_unset.ys
+++ b/misc/scripts/connect_unset.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log connect -unset d q

--- a/misc/scripts/connwrappers.ys
+++ b/misc/scripts/connwrappers.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log connwrappers

--- a/misc/scripts/connwrappers_port.ys
+++ b/misc/scripts/connwrappers_port.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log connwrappers -port $dff d 32000 1

--- a/misc/scripts/connwrappers_signed.ys
+++ b/misc/scripts/connwrappers_signed.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log connwrappers -signed $dff d 3

--- a/misc/scripts/connwrappers_unsigned.ys
+++ b/misc/scripts/connwrappers_unsigned.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log connwrappers -unsigned $dff d 0

--- a/misc/scripts/eval.ys
+++ b/misc/scripts/eval.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log eval middle

--- a/misc/scripts/eval_brute_force_equiv_checker.ys
+++ b/misc/scripts/eval_brute_force_equiv_checker.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log eval -brute_force_equiv_checker_x top top

--- a/misc/scripts/eval_set.ys
+++ b/misc/scripts/eval_set.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log eval -set x 1 -set y 0 middle

--- a/misc/scripts/eval_set_undef.ys
+++ b/misc/scripts/eval_set_undef.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log eval -set-undef middle

--- a/misc/scripts/eval_show.ys
+++ b/misc/scripts/eval_show.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log eval -set x 1 -set y 0 -show o middle

--- a/misc/scripts/eval_show_not_set.ys
+++ b/misc/scripts/eval_show_not_set.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log eval -show o middle

--- a/misc/scripts/eval_table.ys
+++ b/misc/scripts/eval_table.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log eval -table o middle

--- a/misc/scripts/eval_table_set.ys
+++ b/misc/scripts/eval_table_set.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log eval -set-undef -table o middle

--- a/misc/scripts/eval_vloghammer_report.ys
+++ b/misc/scripts/eval_vloghammer_report.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log eval -vloghammer_report mid dle x 1

--- a/misc/scripts/eval_vloghammer_report_rtl.ys
+++ b/misc/scripts/eval_vloghammer_report_rtl.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log eval -vloghammer_report u_ rtl y 1

--- a/misc/scripts/freduce.ys
+++ b/misc/scripts/freduce.ys
@@ -1,0 +1,5 @@
+read_verilog ../top.v
+proc
+tee -o result.log freduce
+synth
+tee -o result.log freduce

--- a/misc/scripts/freduce_dump.ys
+++ b/misc/scripts/freduce_dump.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log freduce -dump fred

--- a/misc/scripts/freduce_inv.ys
+++ b/misc/scripts/freduce_inv.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log freduce -inv

--- a/misc/scripts/freduce_stop.ys
+++ b/misc/scripts/freduce_stop.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log freduce -stop 1

--- a/misc/scripts/freduce_v.ys
+++ b/misc/scripts/freduce_v.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log freduce -v

--- a/misc/scripts/freduce_vv.ys
+++ b/misc/scripts/freduce_vv.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log freduce -vv

--- a/misc/scripts/miter_assert.ys
+++ b/misc/scripts/miter_assert.ys
@@ -1,0 +1,4 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log miter -assert -make_outputs top
+tee -o result.log miter -assert -make_outputs middle

--- a/misc/scripts/miter_assert_flatten.ys
+++ b/misc/scripts/miter_assert_flatten.ys
@@ -1,0 +1,4 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log miter -assert -flatten top
+tee -o result.log miter -assert -flatten middle

--- a/misc/scripts/plugin.ys
+++ b/misc/scripts/plugin.ys
@@ -1,0 +1,1 @@
+tee -o result.log plugin

--- a/misc/scripts/plugin_a.ys
+++ b/misc/scripts/plugin_a.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log plugin -i /usr/local/share/yosys/plugins/vhdl.so -a alias

--- a/misc/scripts/plugin_i.ys
+++ b/misc/scripts/plugin_i.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log plugin -i /usr/local/share/yosys/plugins/vhdl.so

--- a/misc/scripts/plugin_l.ys
+++ b/misc/scripts/plugin_l.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+tee -o result.log plugin -l
+plugin -i /usr/local/share/yosys/plugins/vhdl.so -a alias
+tee -o result.log plugin -l

--- a/misc/scripts/rename_enumerate.ys
+++ b/misc/scripts/rename_enumerate.ys
@@ -1,3 +1,3 @@
 read_verilog ../top.v
 proc
-tee -o result.log rename -enumerate
+tee -o result.log rename -enumerate  middle mid_module

--- a/misc/scripts/rename_src.ys
+++ b/misc/scripts/rename_src.ys
@@ -1,3 +1,3 @@
 read_verilog ../top.v
 proc
-tee -o result.log rename -src
+tee -o result.log rename -src middle mid_module

--- a/misc/scripts/rename_wire.ys
+++ b/misc/scripts/rename_wire.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log rename -wire middle mid_module

--- a/misc/scripts/sat_dump_cnf.ys
+++ b/misc/scripts/sat_dump_cnf.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -dump_cnf cnf.cnf middle

--- a/misc/scripts/sat_dump_json.ys
+++ b/misc/scripts/sat_dump_json.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -dump_json json.json  middle

--- a/misc/scripts/sat_dump_vcd.ys
+++ b/misc/scripts/sat_dump_vcd.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -dump_vcd vcd.vcd  middle

--- a/misc/scripts/sat_initsteps.ys
+++ b/misc/scripts/sat_initsteps.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -initsteps 3  middle

--- a/misc/scripts/sat_max.ys
+++ b/misc/scripts/sat_max.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -max 3  middle

--- a/misc/scripts/sat_maxsteps.ys
+++ b/misc/scripts/sat_maxsteps.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -maxsteps 0  middle

--- a/misc/scripts/sat_prove_x.ys
+++ b/misc/scripts/sat_prove_x.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -prove-x x 1  middle

--- a/misc/scripts/sat_set.ys
+++ b/misc/scripts/sat_set.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -set x 3  middle

--- a/misc/scripts/sat_set_all_undef.ys
+++ b/misc/scripts/sat_set_all_undef.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -set-all-undef x  middle

--- a/misc/scripts/sat_set_all_undef_at.ys
+++ b/misc/scripts/sat_set_all_undef_at.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -set-all-undef-at 3 x  middle

--- a/misc/scripts/sat_set_any_undef.ys
+++ b/misc/scripts/sat_set_any_undef.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -set-any-undef x  middle

--- a/misc/scripts/sat_set_any_undef_at.ys
+++ b/misc/scripts/sat_set_any_undef_at.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -set-any-undef-at 3 x  middle

--- a/misc/scripts/sat_set_def.ys
+++ b/misc/scripts/sat_set_def.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -set-def x  middle

--- a/misc/scripts/sat_set_def_at.ys
+++ b/misc/scripts/sat_set_def_at.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -set-def-at 3 x  middle

--- a/misc/scripts/sat_set_init.ys
+++ b/misc/scripts/sat_set_init.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -set-init x 0  middle

--- a/misc/scripts/sat_show.ys
+++ b/misc/scripts/sat_show.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -show x  middle

--- a/misc/scripts/sat_stepsize.ys
+++ b/misc/scripts/sat_stepsize.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -stepsize 3  middle

--- a/misc/scripts/sat_tempinduct_skip.ys
+++ b/misc/scripts/sat_tempinduct_skip.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -tempinduct-skip 3  middle

--- a/misc/scripts/sat_unset_at.ys
+++ b/misc/scripts/sat_unset_at.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sat -unset-at 3 x  middle

--- a/misc/scripts/select.ys
+++ b/misc/scripts/select.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select
+tee -o result.log select -list

--- a/misc/scripts/select_%.ys
+++ b/misc/scripts/select_%.ys
@@ -1,0 +1,5 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %coe:+[Y] */t:$mux %
+tee -o result.log select */t:$mux %coe:+[Y] */t:$mux %%
+tee -o result.log select -list

--- a/misc/scripts/select_%C.ys
+++ b/misc/scripts/select_%C.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %coe:+[Y] */t:$mux %c
+tee -o result.log select -list

--- a/misc/scripts/select_%R.ys
+++ b/misc/scripts/select_%R.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %coe:+[Y] */t:$mux %R
+tee -o result.log select -list

--- a/misc/scripts/select_%R4.ys
+++ b/misc/scripts/select_%R4.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %coe:+[Y] */t:$mux %R 4
+tee -o result.log select -list

--- a/misc/scripts/select_%a.ys
+++ b/misc/scripts/select_%a.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %coe:+[Y] */t:$mux %a
+tee -o result.log select -list

--- a/misc/scripts/select_%ci.ys
+++ b/misc/scripts/select_%ci.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %ci:+[A] */t:$mux
+tee -o result.log select -list

--- a/misc/scripts/select_%cie.ys
+++ b/misc/scripts/select_%cie.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %cie:+[A] */t:$mux
+tee -o result.log select -list

--- a/misc/scripts/select_%co.ys
+++ b/misc/scripts/select_%co.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %co:+[Y] */t:$mux
+tee -o result.log select -list

--- a/misc/scripts/select_%coe.ys
+++ b/misc/scripts/select_%coe.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %coe:+[Y] */t:$mux
+tee -o result.log select -list

--- a/misc/scripts/select_%i.ys
+++ b/misc/scripts/select_%i.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %coe:+[Y] */t:$mux %i
+tee -o result.log select -list

--- a/misc/scripts/select_%m.ys
+++ b/misc/scripts/select_%m.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %coe:+[Y] */t:$mux %M
+tee -o result.log select -list

--- a/misc/scripts/select_%n.ys
+++ b/misc/scripts/select_%n.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %coe:+[Y] */t:$mux %n
+tee -o result.log select -list

--- a/misc/scripts/select_%s.ys
+++ b/misc/scripts/select_%s.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %coe:+[Y] */t:$mux %s
+tee -o result.log select -list

--- a/misc/scripts/select_%u.ys
+++ b/misc/scripts/select_%u.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %coe:+[Y] */t:$mux %u
+tee -o result.log select -list

--- a/misc/scripts/select_%x_%d.ys
+++ b/misc/scripts/select_%x_%d.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %x:+[A] */t:$mux %D
+tee -o result.log select -list

--- a/misc/scripts/select_%xe.ys
+++ b/misc/scripts/select_%xe.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select */t:$mux %xe:+[A] */t:$mux
+tee -o result.log select -list

--- a/misc/scripts/select_add.ys
+++ b/misc/scripts/select_add.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add top
+tee -o result.log select -list

--- a/misc/scripts/select_add_A_more.ys
+++ b/misc/scripts/select_add_A_more.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add a:o>o
+tee -o result.log select -list

--- a/misc/scripts/select_add_a.ys
+++ b/misc/scripts/select_add_a.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add A:top
+tee -o result.log select -list

--- a/misc/scripts/select_add_a_eq.ys
+++ b/misc/scripts/select_add_a_eq.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add A:top=top
+tee -o result.log select -list

--- a/misc/scripts/select_add_a_less.ys
+++ b/misc/scripts/select_add_a_less.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add A:top<top
+tee -o result.log select -list

--- a/misc/scripts/select_add_a_lesseq.ys
+++ b/misc/scripts/select_add_a_lesseq.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add A:top<=top
+tee -o result.log select -list

--- a/misc/scripts/select_add_a_moreeq.ys
+++ b/misc/scripts/select_add_a_moreeq.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add A:top>=top
+tee -o result.log select -list

--- a/misc/scripts/select_add_all.ys
+++ b/misc/scripts/select_add_all.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add *
+tee -o result.log select -list

--- a/misc/scripts/select_add_c.ys
+++ b/misc/scripts/select_add_c.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add c:$2
+tee -o result.log select -list

--- a/misc/scripts/select_add_i.ys
+++ b/misc/scripts/select_add_i.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add i:x
+tee -o result.log select -list

--- a/misc/scripts/select_add_m.ys
+++ b/misc/scripts/select_add_m.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add m:*
+tee -o result.log select -list

--- a/misc/scripts/select_add_mid.ys
+++ b/misc/scripts/select_add_mid.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add top/u_mid
+tee -o result.log select -list

--- a/misc/scripts/select_add_n.ys
+++ b/misc/scripts/select_add_n.ys
@@ -1,0 +1,5 @@
+read_verilog ../top.v
+tee -o result.log select -add n:*
+proc
+tee -o result.log select -add n:*
+tee -o result.log select -list

--- a/misc/scripts/select_add_o.ys
+++ b/misc/scripts/select_add_o.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add o:A
+tee -o result.log select -list

--- a/misc/scripts/select_add_obj.ys
+++ b/misc/scripts/select_add_obj.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add top/o
+tee -o result.log select -list

--- a/misc/scripts/select_add_p.ys
+++ b/misc/scripts/select_add_p.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+tee -o result.log select -add p:$*
+tee -o result.log select -list

--- a/misc/scripts/select_add_r.ys
+++ b/misc/scripts/select_add_r.ys
@@ -1,0 +1,5 @@
+read_verilog ../top.v
+tee -o result.log select -add r:*
+proc
+tee -o result.log select -add r:*
+tee -o result.log select -list

--- a/misc/scripts/select_add_r_eq.ys
+++ b/misc/scripts/select_add_r_eq.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add r:*=*
+tee -o result.log select -list

--- a/misc/scripts/select_add_r_less.ys
+++ b/misc/scripts/select_add_r_less.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add r:add<add
+tee -o result.log select -list

--- a/misc/scripts/select_add_r_lesseq.ys
+++ b/misc/scripts/select_add_r_lesseq.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add r:add<=add
+tee -o result.log select -list

--- a/misc/scripts/select_add_r_more.ys
+++ b/misc/scripts/select_add_r_more.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add r:add>add
+tee -o result.log select -list

--- a/misc/scripts/select_add_r_moreeq.ys
+++ b/misc/scripts/select_add_r_moreeq.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add r:add>=add
+tee -o result.log select -list

--- a/misc/scripts/select_add_s.ys
+++ b/misc/scripts/select_add_s.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add s:1
+tee -o result.log select -list

--- a/misc/scripts/select_add_ss.ys
+++ b/misc/scripts/select_add_ss.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add s:1:6
+tee -o result.log select -list

--- a/misc/scripts/select_add_t.ys
+++ b/misc/scripts/select_add_t.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add t:$add
+tee -o result.log select -list

--- a/misc/scripts/select_add_w.ys
+++ b/misc/scripts/select_add_w.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add w:o
+tee -o result.log select -list

--- a/misc/scripts/select_add_x.ys
+++ b/misc/scripts/select_add_x.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add x:o
+tee -o result.log select -list

--- a/misc/scripts/select_all.ys
+++ b/misc/scripts/select_all.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select *
+tee -o result.log select -list

--- a/misc/scripts/select_assert_any.ys
+++ b/misc/scripts/select_assert_any.ys
@@ -1,0 +1,7 @@
+read_verilog ../top.v
+select -add top
+tee -o result.log select -assert-any  top
+proc
+select -add top
+tee -o result.log select -assert-any  top
+tee -o result.log select -list

--- a/misc/scripts/select_assert_count.ys
+++ b/misc/scripts/select_assert_count.ys
@@ -1,0 +1,6 @@
+read_verilog ../top.v
+select -add top
+tee -o result.log select -assert-count 11 top
+proc
+tee -o result.log select -assert-count 11 top
+tee -o result.log select -list

--- a/misc/scripts/select_assert_count_mem.ys
+++ b/misc/scripts/select_assert_count_mem.ys
@@ -1,0 +1,6 @@
+read_verilog ../top.v
+select -add top
+tee -o result.log select -assert-count 32 top
+proc
+tee -o result.log select -assert-count 62 top
+tee -o result.log select -list

--- a/misc/scripts/select_assert_max.ys
+++ b/misc/scripts/select_assert_max.ys
@@ -1,0 +1,7 @@
+read_verilog ../top.v
+select -add top
+tee -o result.log select -assert-max 15 top
+proc
+select -add top
+tee -o result.log select -assert-max 15 top
+tee -o result.log select -list

--- a/misc/scripts/select_assert_max_mem.ys
+++ b/misc/scripts/select_assert_max_mem.ys
@@ -1,0 +1,7 @@
+read_verilog ../top.v
+select -add top
+tee -o result.log select -assert-max 32 top
+proc
+select -add top
+tee -o result.log select -assert-max 62 top
+tee -o result.log select -list

--- a/misc/scripts/select_assert_min.ys
+++ b/misc/scripts/select_assert_min.ys
@@ -1,0 +1,7 @@
+read_verilog ../top.v
+select -add top
+tee -o result.log select -assert-min 2 top
+proc
+select -add top
+tee -o result.log select -assert-min 2 top
+tee -o result.log select -list

--- a/misc/scripts/select_assert_none.ys
+++ b/misc/scripts/select_assert_none.ys
@@ -1,0 +1,7 @@
+read_verilog ../top.v
+select -none
+tee -o result.log select -assert-none x
+proc
+select -none
+tee -o result.log select -assert-none x
+tee -o result.log select -list

--- a/misc/scripts/select_cd.ys
+++ b/misc/scripts/select_cd.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log cd

--- a/misc/scripts/select_cd_module.ys
+++ b/misc/scripts/select_cd_module.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log cd middle

--- a/misc/scripts/select_cd_up.ys
+++ b/misc/scripts/select_cd_up.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log cd middle
+tee -o result.log cd ..

--- a/misc/scripts/select_clear.ys
+++ b/misc/scripts/select_clear.ys
@@ -1,0 +1,5 @@
+read_verilog ../top.v
+proc
+select -add top -add middle
+tee -o result.log select -clear
+tee -o result.log select -list

--- a/misc/scripts/select_count.ys
+++ b/misc/scripts/select_count.ys
@@ -1,0 +1,5 @@
+read_verilog ../top.v
+proc
+select -add top -add middle
+tee -o result.log select -count
+tee -o result.log select -list

--- a/misc/scripts/select_del.ys
+++ b/misc/scripts/select_del.ys
@@ -1,0 +1,5 @@
+read_verilog ../top.v
+proc
+select -add top
+tee -o result.log select -del top
+tee -o result.log select -list

--- a/misc/scripts/select_list.ys
+++ b/misc/scripts/select_list.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+select -add top -add middle
+tee -o result.log select -list

--- a/misc/scripts/select_ls.ys
+++ b/misc/scripts/select_ls.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log select -add top
+tee -o result.log ls

--- a/misc/scripts/select_ls_top.ys
+++ b/misc/scripts/select_ls_top.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log ls top

--- a/misc/scripts/select_module.ys
+++ b/misc/scripts/select_module.ys
@@ -1,0 +1,5 @@
+read_verilog ../top.v
+proc
+select -add top -add middle
+tee -o result.log select -module middle
+tee -o result.log select -list

--- a/misc/scripts/select_module_mem.ys
+++ b/misc/scripts/select_module_mem.ys
@@ -1,0 +1,5 @@
+read_verilog ../top.v
+proc
+select -add top -add top
+tee -o result.log select -module top
+tee -o result.log select -list

--- a/misc/scripts/select_none.ys
+++ b/misc/scripts/select_none.ys
@@ -1,0 +1,5 @@
+read_verilog ../top.v
+proc
+select -add top -add middle
+tee -o result.log select -none
+tee -o result.log select -list

--- a/misc/scripts/select_read.ys
+++ b/misc/scripts/select_read.ys
@@ -1,0 +1,6 @@
+read_verilog ../top.v
+proc
+select -add top -add middle
+select -write select_f
+tee -o result.log select -read select_f
+tee -o result.log select -list

--- a/misc/scripts/select_set.ys
+++ b/misc/scripts/select_set.ys
@@ -1,0 +1,6 @@
+read_verilog ../top.v
+proc
+select -add top
+tee -o result.log select -set top top
+tee -o result.log select @top
+tee -o result.log select -list

--- a/misc/scripts/select_write.ys
+++ b/misc/scripts/select_write.ys
@@ -1,0 +1,5 @@
+read_verilog ../top.v
+proc
+select -add top -add middle
+tee -o result.log select -write select_f
+tee -o result.log select -list

--- a/misc/scripts/setattr.ys
+++ b/misc/scripts/setattr.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setattr

--- a/misc/scripts/setattr_mod.ys
+++ b/misc/scripts/setattr_mod.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setattr -mod -set u 1 top

--- a/misc/scripts/setattr_set.ys
+++ b/misc/scripts/setattr_set.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setattr -set u 1 top

--- a/misc/scripts/setattr_set_proc.ys
+++ b/misc/scripts/setattr_set_proc.ys
@@ -1,0 +1,2 @@
+read_verilog ../top.v
+tee -o result.log setattr -set u 1 top

--- a/misc/scripts/setattr_top.ys
+++ b/misc/scripts/setattr_top.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setattr top

--- a/misc/scripts/setattr_unset.ys
+++ b/misc/scripts/setattr_unset.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log setattr -set u 1 top
+tee -o result.log setattr -unset u top

--- a/misc/scripts/setparam.ys
+++ b/misc/scripts/setparam.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setparam

--- a/misc/scripts/setparam_set.ys
+++ b/misc/scripts/setparam_set.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setparam -set WIDTH 1 top

--- a/misc/scripts/setparam_top.ys
+++ b/misc/scripts/setparam_top.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setparam top

--- a/misc/scripts/setparam_type.ys
+++ b/misc/scripts/setparam_type.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setparam -type $mux -set WIDTH 1 top

--- a/misc/scripts/setparam_unset.ys
+++ b/misc/scripts/setparam_unset.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+proc
+tee -o result.log setparam -set WIDTH 1 top
+tee -o result.log setparam -unset WIDT top

--- a/misc/scripts/setundef_anyconst.ys
+++ b/misc/scripts/setundef_anyconst.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setundef -anyconst

--- a/misc/scripts/setundef_anyseq.ys
+++ b/misc/scripts/setundef_anyseq.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setundef -anyseq

--- a/misc/scripts/setundef_expose.ys
+++ b/misc/scripts/setundef_expose.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setundef -zero -expose -undriven

--- a/misc/scripts/setundef_init.ys
+++ b/misc/scripts/setundef_init.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setundef -zero -init

--- a/misc/scripts/setundef_one.ys
+++ b/misc/scripts/setundef_one.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setundef -one

--- a/misc/scripts/setundef_random.ys
+++ b/misc/scripts/setundef_random.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setundef -random 256

--- a/misc/scripts/setundef_undef.ys
+++ b/misc/scripts/setundef_undef.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setundef -undef

--- a/misc/scripts/setundef_undriven.ys
+++ b/misc/scripts/setundef_undriven.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log setundef -zero -undriven

--- a/misc/scripts/sim.ys
+++ b/misc/scripts/sim.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log sim top

--- a/misc/scripts/sim_a.ys
+++ b/misc/scripts/sim_a.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log sim -a top

--- a/misc/scripts/sim_clock.ys
+++ b/misc/scripts/sim_clock.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log sim -clock x top

--- a/misc/scripts/sim_clock_mem.ys
+++ b/misc/scripts/sim_clock_mem.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sim -clock clk top

--- a/misc/scripts/sim_clockn.ys
+++ b/misc/scripts/sim_clockn.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sim -clockn clk top

--- a/misc/scripts/sim_d.ys
+++ b/misc/scripts/sim_d.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log sim -d top

--- a/misc/scripts/sim_n.ys
+++ b/misc/scripts/sim_n.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log sim -n 5 top

--- a/misc/scripts/sim_reset.ys
+++ b/misc/scripts/sim_reset.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sim -reset we_b top

--- a/misc/scripts/sim_resetn.ys
+++ b/misc/scripts/sim_resetn.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+proc
+tee -o result.log sim -resetn we_a top

--- a/misc/scripts/sim_rstlen.ys
+++ b/misc/scripts/sim_rstlen.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log sim -rstlen 2 top

--- a/misc/scripts/sim_vcd.ys
+++ b/misc/scripts/sim_vcd.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log sim -vcd vcd.vcd top

--- a/misc/scripts/sim_w.ys
+++ b/misc/scripts/sim_w.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log sim -w top

--- a/misc/scripts/sim_zinit.ys
+++ b/misc/scripts/sim_zinit.ys
@@ -1,0 +1,3 @@
+read_verilog -sv ../top.v
+proc
+tee -o result.log sim -zinit top

--- a/misc/scripts/sim_zinit_mem.ys
+++ b/misc/scripts/sim_zinit_mem.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+memory_collect
+proc
+tee -o result.log sim -zinit top

--- a/misc/select/top.v
+++ b/misc/select/top.v
@@ -1,0 +1,33 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output reg A,
+ output cout
+ );
+ wire o;
+
+`ifndef BUG
+always @(posedge cin)
+	A <= o;
+
+assign cout =  cin? y : x;
+
+middle u_mid (x,y,o);
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module middle
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule

--- a/misc/select_cd/top.v
+++ b/misc/select_cd/top.v
@@ -1,0 +1,33 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output reg A,
+ output cout
+ );
+ wire o;
+
+`ifndef BUG
+always @(posedge cin)
+	A <= o;
+
+assign cout =  cin? y : x;
+
+middle u_mid (x,y,o);
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module middle
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule

--- a/misc/select_ls/top.v
+++ b/misc/select_ls/top.v
@@ -1,0 +1,33 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output reg A,
+ output cout
+ );
+ wire o;
+
+`ifndef BUG
+always @(posedge cin)
+	A <= o;
+
+assign cout =  cin? y : x;
+
+middle u_mid (x,y,o);
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module middle
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule

--- a/misc/select_mem/top.v
+++ b/misc/select_mem/top.v
@@ -1,0 +1,47 @@
+module top
+(
+	input [7:0] data_a, data_b,
+	input [5:0] addr_a, addr_b,
+	input we_a, we_b, clk,
+	output reg [7:0] q_a, q_b
+);
+	// Declare the RAM variable
+	reg [7:0] ram[63:0];
+	
+	// Port A
+	always @ (posedge clk)
+	begin
+`ifndef BUG        
+		if (we_a) 
+`else        
+		if (we_b) 
+`endif
+		begin
+			ram[addr_a] <= data_a;
+			q_a <= data_a;
+		end
+		else 
+		begin
+			q_a <= ram[addr_a];
+		end
+	end
+	
+	// Port B
+	always @ (posedge clk)
+	begin
+`ifndef BUG        
+		if (we_b) 
+`else        
+		if (we_a) 
+`endif
+		begin
+			ram[addr_b] <= data_b;
+			q_b <= data_b;
+		end
+		else
+		begin
+			q_b <= ram[addr_b];
+		end
+	end
+	
+endmodule								 

--- a/misc/select_stack/top.v
+++ b/misc/select_stack/top.v
@@ -1,0 +1,33 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output reg A,
+ output cout
+ );
+ wire o;
+
+`ifndef BUG
+always @(posedge cin)
+	A <= o;
+
+assign cout =  cin? y : x;
+
+middle u_mid (x,y,o);
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module middle
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule

--- a/misc/setattr/top.v
+++ b/misc/setattr/top.v
@@ -1,0 +1,33 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output reg A,
+ output cout
+ );
+ wire o;
+
+`ifndef BUG
+always @(posedge cin)
+	A <= o;
+
+assign cout =  cin? y : x;
+
+middle u_mid (x,y,o);
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module middle
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule

--- a/misc/setattr_mem/top.v
+++ b/misc/setattr_mem/top.v
@@ -1,0 +1,47 @@
+module top
+(
+	input [7:0] data_a, data_b,
+	input [5:0] addr_a, addr_b,
+	input we_a, we_b, clk,
+	output reg [7:0] q_a, q_b
+);
+	// Declare the RAM variable
+	reg [7:0] ram[63:0];
+	
+	// Port A
+	always @ (posedge clk)
+	begin
+`ifndef BUG        
+		if (we_a) 
+`else        
+		if (we_b) 
+`endif
+		begin
+			ram[addr_a] <= data_a;
+			q_a <= data_a;
+		end
+		else 
+		begin
+			q_a <= ram[addr_a];
+		end
+	end
+	
+	// Port B
+	always @ (posedge clk)
+	begin
+`ifndef BUG        
+		if (we_b) 
+`else        
+		if (we_a) 
+`endif
+		begin
+			ram[addr_b] <= data_b;
+			q_b <= data_b;
+		end
+		else
+		begin
+			q_b <= ram[addr_b];
+		end
+	end
+	
+endmodule								 

--- a/misc/setparam/top.v
+++ b/misc/setparam/top.v
@@ -1,0 +1,34 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output reg A,
+ output cout
+ );
+ parameter WIDTH = 1;
+ wire o;
+
+`ifndef BUG
+always @(posedge cin)
+	A <= o;
+
+assign cout =  cin? y : x;
+
+middle u_mid (x,y,o);
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module middle
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule

--- a/misc/setundef/top.v
+++ b/misc/setundef/top.v
@@ -1,0 +1,34 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output reg A,
+ output cout
+ );
+ parameter X = 1;
+ wire o;
+
+`ifndef BUG
+always @(posedge cin)
+	A <= o;
+
+//assign cout =  cin? y : x;
+
+middle u_mid (.x(x),.o(o));
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module middle
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule

--- a/misc/sim/top.v
+++ b/misc/sim/top.v
@@ -1,0 +1,45 @@
+module top
+(
+ input x,
+ input y,
+ input cin,
+
+ output reg A,
+ output cout
+ );
+ parameter X = 1;
+ wire o;
+
+`ifndef BUG
+always @(posedge cin)
+	A <= o;
+
+//assign cout =  cin? y : x;
+
+middle u_mid (.x(x),.o(o));
+u_rtl inst_u_rtl (.x(x),.o(o));
+`else
+assign {cout,A} =  cin - y * x;
+`endif
+
+endmodule
+
+module middle
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule
+
+module u_rtl
+(
+	input x,
+	input y,
+	output o
+);
+
+assign o = x + y;
+endmodule

--- a/misc/sim_mem/top.v
+++ b/misc/sim_mem/top.v
@@ -1,0 +1,47 @@
+module top
+(
+	input [7:0] data_a, data_b,
+	input [5:0] addr_a, addr_b,
+	input we_a, we_b, clk,
+	output reg [7:0] q_a, q_b
+);
+	// Declare the RAM variable
+	reg [7:0] ram[63:0];
+	
+	// Port A
+	always @ (posedge clk)
+	begin
+`ifndef BUG        
+		if (we_a) 
+`else        
+		if (we_b) 
+`endif
+		begin
+			ram[addr_a] <= data_a;
+			q_a <= data_a;
+		end
+		else 
+		begin
+			q_a <= ram[addr_a];
+		end
+	end
+	
+	// Port B
+	always @ (posedge clk)
+	begin
+`ifndef BUG        
+		if (we_b) 
+`else        
+		if (we_a) 
+`endif
+		begin
+			ram[addr_b] <= data_b;
+			q_b <= data_b;
+		end
+		else
+		begin
+			q_b <= ram[addr_b];
+		end
+	end
+	
+endmodule								 

--- a/simple/Makefile
+++ b/simple/Makefile
@@ -107,5 +107,16 @@ $(eval $(call template,extract_counter_sync_reset,extract_counter extract_counte
 $(eval $(call template,shregmap,shregmap shregmap_clkpol_any shregmap_clkpol_neg shregmap_clkpol_pos shregmap_enpol_any shregmap_enpol_any_or_none shregmap_enpol_neg shregmap_enpol_none shregmap_enpol_pos shregmap_init shregmap_keep_after shregmap_keep_before shregmap_match shregmap_maxlen shregmap_minlen shregmap_params shregmap_tech shregmap_zinit))
 $(eval $(call template,shregmap_resetable,shregmap shregmap_clkpol_any shregmap_clkpol_neg shregmap_clkpol_pos shregmap_enpol_any shregmap_enpol_any_or_none shregmap_enpol_neg shregmap_enpol_none shregmap_enpol_pos shregmap_init shregmap_keep_after shregmap_keep_before shregmap_match shregmap_maxlen shregmap_minlen shregmap_params shregmap_tech shregmap_zinit))
 
+#design_import
+$(eval $(call template,design_import, design_import design_import_as ))
+
+#async2sync
+$(eval $(call template,async2sync,async2sync))
+
+#flowmap
+$(eval $(call template,flowmap,flowmap flowmap_cells flowmap_debug_relax flowmap_debug flowmap_maxlut flowmap_minlut flowmap_optarea flowmap_r_alpha flowmap_r_beta flowmap_r_gamma flowmap_relax flowmap_relax_debug flowmap_relax_debug_relax flowmap_top))
+$(eval $(call template,flowmap_latch,flowmap flowmap_cells flowmap_debug_relax flowmap_debug flowmap_maxlut flowmap_minlut flowmap_optarea flowmap_r_alpha flowmap_r_beta flowmap_r_gamma flowmap_relax  flowmap_relax_debug flowmap_relax_debug_relax flowmap_top))
+$(eval $(call template,flowmap_mem,flowmap flowmap_cells flowmap_debug_relax flowmap_debug flowmap_maxlut flowmap_minlut flowmap_optarea flowmap_r_alpha flowmap_r_beta flowmap_r_gamma flowmap_relax flowmap_relax_debug flowmap_relax_debug_relax flowmap_top))
+
 
 .PHONY: all clean

--- a/simple/async2sync/testbench.v
+++ b/simple/async2sync/testbench.v
@@ -1,0 +1,77 @@
+module testbench;
+    reg clk;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 clk = 0;
+        repeat (10000) begin
+            #5 clk = 1;
+            #5 clk = 0;
+        end
+
+        $display("OKAY");    
+    end
+   
+    
+    reg [2:0] dinA = 0;
+    wire doutB,doutB1,doutB2,doutB3,doutB4;
+	reg dff,ndff,adff,adffn,dffe = 0;
+
+    top uut (
+        .clk (clk ),
+        .a (dinA[0] ),
+        .pre (dinA[1] ),
+        .clr (dinA[2] ),
+        .b (doutB ),
+        .b1 (doutB1 ),
+        .b2 (doutB2 ),
+        .b3 (doutB3 ),
+        .b4 (doutB4 )
+    );
+    
+    always @(posedge clk) begin
+    #3;
+    dinA <= dinA + 1;
+    end
+	
+	always @( posedge clk, posedge dinA[1], posedge dinA[2] )
+		if ( dinA[2] )
+			dff <= 1'b0;
+		else if ( dinA[1] )
+			dff <= 1'b1;
+		else
+            dff <= dinA[0];
+    
+    always @( negedge clk, negedge dinA[1], negedge dinA[2] )
+		if ( !dinA[2] )
+			ndff <= 1'b0;
+		else if ( !dinA[1] )
+			ndff <= 1'b1;
+		else
+            ndff <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+			adff <= 1'b0;
+		else
+            adff <= dinA[0];
+            
+    always @( posedge clk, negedge dinA[2] )
+		if ( !dinA[2] )
+			adffn <= 1'b0;
+		else
+            adffn <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+            dffe <= dinA[0];
+            
+	assert_dff dff_test(.clk(clk), .test(doutB), .pat(dff));
+    assert_dff ndff_test(.clk(clk), .test(doutB1), .pat(ndff));
+    assert_dff adff_test(.clk(clk), .test(doutB2), .pat(adff));    
+    assert_dff adffn_test(.clk(clk), .test(doutB3), .pat(adffn));
+    assert_dff dffe_test(.clk(clk), .test(doutB4), .pat(dffe));
+    
+endmodule

--- a/simple/async2sync/top.v
+++ b/simple/async2sync/top.v
@@ -1,0 +1,128 @@
+module adff
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module adffn
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module dffe
+    ( input d, clk, en, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge en )
+		if ( en )
+`ifndef BUG        
+			q <= d;
+`else        
+			q <= 1'b0;
+`endif
+endmodule
+
+module dffsr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge pre, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module ndffnsnr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( negedge clk, negedge pre, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( !pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module top (
+input clk,
+input clr,
+input pre,
+input a,
+output b,b1,b2,b3,b4
+);
+
+dffsr u_dffsr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b )
+    );
+    
+ndffnsnr u_ndffnsnr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b1 )
+    );
+    
+adff u_adff (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b2 )
+    );
+    
+adffn u_adffn (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b3 )
+    );
+    
+dffe u_dffe (
+        .clk (clk ),
+        .en (clr),
+        .d (a ),
+        .q (b4 )
+    );
+
+endmodule

--- a/simple/design_import/testbench.v
+++ b/simple/design_import/testbench.v
@@ -1,0 +1,42 @@
+module testbench;
+    reg [7:0] in;
+
+	wire pi_and,i_and;
+	wire pi_or,i_or;
+	wire pi_xor,i_xor;
+	wire pi_nand,i_nand;
+	wire pi_nor,i_nor;
+	wire pi_xnor,i_xnor;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 in = 0;
+        repeat (10000) begin
+            #5 in = in + 1;
+        end
+
+        $display("OKAY");
+    end
+
+    top uut (
+	.x(in),
+	.o_and(i_and),
+	.o_or(i_or),
+	.o_xor(i_xor),
+	.o_nand(i_nand),
+	.o_nor(i_nor),
+	.o_xnor(i_xnor)
+	);
+	
+	assign pi_and =  &in;
+	assign pi_or =  |in;
+	assign pi_xor =  ^in;
+	assign pi_nand =  ~&in;
+	assign pi_nor =  ~|in;
+	assign pi_xnor =  ~^in;
+
+	assert_comb and_test(.A(pi_and), .B(i_and));
+
+endmodule

--- a/simple/design_import/top.v
+++ b/simple/design_import/top.v
@@ -1,0 +1,29 @@
+module top
+(
+ input [7:0] x,
+
+ output o_and,
+ output o_or,
+ output o_xor,
+ output o_nand,
+ output o_nor,
+ output o_xnor
+ );
+
+`ifndef BUG
+assign o_and =  &x;
+assign o_or =  |x;
+assign o_xor =  ^x;
+assign o_nand =  ~&x;
+assign o_nor =  ~|x;
+assign o_xnor =  ~^x;
+`else
+assign o_and =  ~&x;
+assign o_or =  &x;
+assign o_xor =  ~^x;
+assign o_nand =  &x;
+assign o_nor =  ^x;
+assign o_xnor =  ~&x;
+`endif
+
+endmodule

--- a/simple/flowmap/testbench.v
+++ b/simple/flowmap/testbench.v
@@ -1,0 +1,77 @@
+module testbench;
+    reg clk;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 clk = 0;
+        repeat (10000) begin
+            #5 clk = 1;
+            #5 clk = 0;
+        end
+
+        $display("OKAY");    
+    end
+   
+    
+    reg [2:0] dinA = 0;
+    wire doutB,doutB1,doutB2,doutB3,doutB4;
+	reg dff,ndff,adff,adffn,dffe = 0;
+
+    top uut (
+        .clk (clk ),
+        .a (dinA[0] ),
+        .pre (dinA[1] ),
+        .clr (dinA[2] ),
+        .b (doutB ),
+        .b1 (doutB1 ),
+        .b2 (doutB2 ),
+        .b3 (doutB3 ),
+        .b4 (doutB4 )
+    );
+    
+    always @(posedge clk) begin
+    #3;
+    dinA <= dinA + 1;
+    end
+	
+	always @( posedge clk, posedge dinA[1], posedge dinA[2] )
+		if ( dinA[2] )
+			dff <= 1'b0;
+		else if ( dinA[1] )
+			dff <= 1'b1;
+		else
+            dff <= dinA[0];
+    
+    always @( negedge clk, negedge dinA[1], negedge dinA[2] )
+		if ( !dinA[2] )
+			ndff <= 1'b0;
+		else if ( !dinA[1] )
+			ndff <= 1'b1;
+		else
+            ndff <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+			adff <= 1'b0;
+		else
+            adff <= dinA[0];
+            
+    always @( posedge clk, negedge dinA[2] )
+		if ( !dinA[2] )
+			adffn <= 1'b0;
+		else
+            adffn <= dinA[0];
+            
+    always @( posedge clk, posedge dinA[2] )
+		if ( dinA[2] )
+            dffe <= dinA[0];
+            
+	assert_dff dff_test(.clk(clk), .test(doutB), .pat(dff));
+    assert_dff ndff_test(.clk(clk), .test(doutB1), .pat(ndff));
+    assert_dff adff_test(.clk(clk), .test(doutB2), .pat(adff));    
+    assert_dff adffn_test(.clk(clk), .test(doutB3), .pat(adffn));
+    assert_dff dffe_test(.clk(clk), .test(doutB4), .pat(dffe));
+    
+endmodule

--- a/simple/flowmap/top.v
+++ b/simple/flowmap/top.v
@@ -1,0 +1,128 @@
+module adff
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module adffn
+    ( input d, clk, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else
+            q <= d;
+endmodule
+
+module dffe
+    ( input d, clk, en, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge en )
+		if ( en )
+`ifndef BUG        
+			q <= d;
+`else        
+			q <= 1'b0;
+`endif
+endmodule
+
+module dffsr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( posedge clk, posedge pre, posedge clr )
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module ndffnsnr
+    ( input d, clk, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @( negedge clk, negedge pre, negedge clr )
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( !pre )
+			q <= 1'b1;
+		else
+            q <= d;
+endmodule
+
+module top (
+input clk,
+input clr,
+input pre,
+input a,
+output b,b1,b2,b3,b4
+);
+
+dffsr u_dffsr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b )
+    );
+    
+ndffnsnr u_ndffnsnr (
+        .clk (clk ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b1 )
+    );
+    
+adff u_adff (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b2 )
+    );
+    
+adffn u_adffn (
+        .clk (clk ),
+        .clr (clr),
+        .d (a ),
+        .q (b3 )
+    );
+    
+dffe u_dffe (
+        .clk (clk ),
+        .en (clr),
+        .d (a ),
+        .q (b4 )
+    );
+
+endmodule

--- a/simple/flowmap_latch/testbench.v
+++ b/simple/flowmap_latch/testbench.v
@@ -1,0 +1,72 @@
+module testbench;
+    reg en;
+
+    initial begin
+         $dumpfile("testbench.vcd");
+         $dumpvars(0, testbench);
+
+        #5 en = 0;
+        repeat (10000) begin
+            #5 en = 1;
+            #5 en = 0;
+        end
+
+        $display("OKAY");    
+    end
+   
+    
+    reg [2:0] dinA = 0;
+    wire doutB,doutB1,doutB2,doutB3;
+	reg lat,nlat,alat,alatn = 0;
+
+    top uut (
+        .en (en ),
+        .a (dinA[0] ),
+        .pre (dinA[1] ),
+        .clr (dinA[2] ),
+        .b (doutB ),
+        .b1 (doutB1 ),
+        .b2 (doutB2 ),
+        .b3 (doutB3 )
+    );
+    
+    always @(posedge en) begin
+    #3;
+    dinA <= dinA + 1;
+    end
+	
+	always @( en or dinA[0] or dinA[1] or dinA[2] )
+		if ( dinA[2] )
+			lat <= 1'b0;
+		else if ( dinA[1] )
+			lat <= 1'b1;
+		else if ( en )
+            lat <= dinA[0];
+    
+    always @( en or dinA[0] or dinA[1] or dinA[2] )
+		if ( !dinA[2] )
+			nlat <= 1'b0;
+		else if ( !dinA[1] )
+			nlat <= 1'b1;
+		else if (!en)
+            nlat <= dinA[0];
+            
+    always @( en or dinA[0] or dinA[2] )
+		if ( dinA[2] )
+			alat <= 1'b0;
+		else if (en)
+            alat <= dinA[0];
+            
+    always @( en or dinA[0] or dinA[2] )
+		if ( !dinA[2] )
+			alatn <= 1'b0;
+		else if (!en)
+            alatn <= dinA[0];
+            
+            
+	assert_dff lat_test(.clk(en), .test(doutB), .pat(lat));
+    assert_dff nlat_test(.clk(en), .test(doutB1), .pat(nlat));
+    assert_dff alat_test(.clk(en), .test(doutB2), .pat(alat));    
+    assert_dff alatn_test(.clk(en), .test(doutB3), .pat(alatn));
+    
+endmodule

--- a/simple/flowmap_latch/top.v
+++ b/simple/flowmap_latch/top.v
@@ -1,0 +1,107 @@
+module alat
+    ( input d, en, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @(*)
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if (en)
+            q <= d;
+endmodule
+
+module alatn
+    ( input d, en, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @(*)
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if (!en)
+            q <= d;
+endmodule
+
+module latsr
+    ( input d, en, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @(*)
+		if ( clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( pre )
+			q <= 1'b1;
+		else if ( en )
+            q <= d;
+endmodule
+
+module nlatsr
+    ( input d, en, pre, clr, output reg q );
+    initial begin
+      q = 0;
+    end
+	always @(*)
+		if ( !clr )
+`ifndef BUG        
+			q <= 1'b0;
+`else        
+			q <= d;
+`endif
+		else if ( !pre )
+			q <= 1'b1;
+		else if ( !en )
+            q <= d;
+endmodule
+
+module top (
+input en,
+input clr,
+input pre,
+input a,
+output b,b1,b2,b3
+);
+
+latsr u_latsr (
+        .en (en ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b )
+    );
+    
+nlatsr u_nlatsr (
+        .en (en ),
+        .clr (clr),
+        .pre (pre),
+        .d (a ),
+        .q (b1 )
+    );
+    
+alat u_alat (
+        .en (en ),
+        .clr (clr),
+        .d (a ),
+        .q (b2 )
+    );
+    
+alatn u_alatn (
+        .en (en ),
+        .clr (clr),
+        .d (a ),
+        .q (b3 )
+    );
+    
+endmodule

--- a/simple/flowmap_mem/testbench.v
+++ b/simple/flowmap_mem/testbench.v
@@ -1,0 +1,68 @@
+module testbench;
+    reg clk;
+
+    initial begin
+        // $dumpfile("testbench.vcd");
+        // $dumpvars(0, testbench);
+
+        #5 clk = 0;
+        repeat (10000) begin
+            #5 clk = 1;
+            #5 clk = 0;
+        end
+
+        $display("OKAY");    
+    end
+   
+    
+    reg [7:0] data_a = 0;
+	reg [7:0] data_b = 0;
+	reg [5:0] addr_a = 0;	
+	reg [5:0] addr_b = 0;
+    reg we_a = 0;
+	reg we_b = 1;
+	wire [7:0] q_a,q_b;
+
+    top uut (
+    .data_a(data_a),
+	.data_b(data_b),
+	.addr_a(addr_a),
+	.addr_b(addr_b),
+	.we_a(we_a), 
+	.we_b(we_b), 
+	.clk(clk),
+	.q_a(q_a), 
+	.q_b(q_b)
+    );
+    
+    always @(posedge clk) begin
+    #3;
+    data_a <= data_a + 17;	
+    data_b <= data_b + 5;
+	
+    addr_a <= addr_a + 1;	
+    addr_b <= addr_b + 1;
+    end
+	
+	always @(posedge clk) begin
+    //#3;
+    we_a <= !we_a; 
+    we_b <= !we_b; 
+    end
+	
+	uut_mem_checker port_a_test(.clk(clk), .en(!we_a), .A(q_a));
+    uut_mem_checker port_b_test(.clk(clk), .en(!we_b), .A(q_b));
+    
+endmodule
+
+module uut_mem_checker(input clk, input en, input [7:0] A);
+    always @(posedge clk)
+    begin
+        #1;
+        if (en == 1 & A === 8'bXXXXXXXX)
+        begin
+            $display("ERROR: ASSERTION FAILED in %m:",$time," ",A);
+            $stop;
+        end
+    end
+endmodule

--- a/simple/flowmap_mem/top.v
+++ b/simple/flowmap_mem/top.v
@@ -1,0 +1,47 @@
+module top
+(
+	input [7:0] data_a, data_b,
+	input [5:0] addr_a, addr_b,
+	input we_a, we_b, clk,
+	output reg [7:0] q_a, q_b
+);
+	// Declare the RAM variable
+	reg [7:0] ram[63:0];
+	
+	// Port A
+	always @ (posedge clk)
+	begin
+`ifndef BUG        
+		if (we_a) 
+`else        
+		if (we_b) 
+`endif
+		begin
+			ram[addr_a] <= data_a;
+			q_a <= data_a;
+		end
+		else 
+		begin
+			q_a <= ram[addr_a];
+		end
+	end
+	
+	// Port B
+	always @ (posedge clk)
+	begin
+`ifndef BUG        
+		if (we_b) 
+`else        
+		if (we_a) 
+`endif
+		begin
+			ram[addr_b] <= data_b;
+			q_b <= data_b;
+		end
+		else
+		begin
+			q_b <= ram[addr_b];
+		end
+	end
+	
+endmodule								 

--- a/simple/scripts/async2sync.ys
+++ b/simple/scripts/async2sync.ys
@@ -1,0 +1,5 @@
+read_verilog ../top.v
+proc
+async2sync
+synth -top top
+write_verilog synth.v

--- a/simple/scripts/design_import.ys
+++ b/simple/scripts/design_import.ys
@@ -1,0 +1,5 @@
+read_verilog ../top.v
+proc
+design -save top
+design -import top
+write_verilog synth.v

--- a/simple/scripts/design_import_as.ys
+++ b/simple/scripts/design_import_as.ys
@@ -1,0 +1,5 @@
+read_verilog ../top.v
+proc
+design -save top
+design -import top -as top_new
+write_verilog synth.v

--- a/simple/scripts/flowmap.ys
+++ b/simple/scripts/flowmap.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+synth -top top
+flowmap
+write_verilog synth.v

--- a/simple/scripts/flowmap_cells.ys
+++ b/simple/scripts/flowmap_cells.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+synth -top top
+flowmap -cells $dff top
+write_verilog synth.v

--- a/simple/scripts/flowmap_debug.ys
+++ b/simple/scripts/flowmap_debug.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+synth -top top
+flowmap -debug top
+write_verilog synth.v

--- a/simple/scripts/flowmap_debug_relax.ys
+++ b/simple/scripts/flowmap_debug_relax.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+synth -top top
+flowmap -debug-relax top
+write_verilog synth.v

--- a/simple/scripts/flowmap_maxlut.ys
+++ b/simple/scripts/flowmap_maxlut.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+synth -top top
+flowmap -maxlut 4 top
+write_verilog synth.v

--- a/simple/scripts/flowmap_minlut.ys
+++ b/simple/scripts/flowmap_minlut.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+synth -top top
+flowmap -minlut 2 top
+write_verilog synth.v

--- a/simple/scripts/flowmap_optarea.ys
+++ b/simple/scripts/flowmap_optarea.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+synth -top top
+flowmap -optarea 3 top
+write_verilog synth.v

--- a/simple/scripts/flowmap_r_alpha.ys
+++ b/simple/scripts/flowmap_r_alpha.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+synth -top top
+flowmap -r-alpha 3 top
+write_verilog synth.v

--- a/simple/scripts/flowmap_r_beta.ys
+++ b/simple/scripts/flowmap_r_beta.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+synth -top top
+flowmap -r-beta 3 top
+write_verilog synth.v

--- a/simple/scripts/flowmap_r_gamma.ys
+++ b/simple/scripts/flowmap_r_gamma.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+synth -top top
+flowmap -r-gamma 3 top
+write_verilog synth.v

--- a/simple/scripts/flowmap_relax.ys
+++ b/simple/scripts/flowmap_relax.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+synth -top top
+flowmap -relax top
+write_verilog synth.v

--- a/simple/scripts/flowmap_relax_debug.ys
+++ b/simple/scripts/flowmap_relax_debug.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+synth -top top
+flowmap -relax -debug top
+write_verilog synth.v

--- a/simple/scripts/flowmap_relax_debug_relax.ys
+++ b/simple/scripts/flowmap_relax_debug_relax.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+synth -top top
+flowmap -relax -debug-relax top
+write_verilog synth.v

--- a/simple/scripts/flowmap_top.ys
+++ b/simple/scripts/flowmap_top.ys
@@ -1,0 +1,4 @@
+read_verilog ../top.v
+synth -top top
+flowmap top
+write_verilog synth.v


### PR DESCRIPTION
Testing problems:
3. bugpoint ERROR: No such command: autoidx (type 'help' for a command overview)
6. connect_nomap_port connect_port - ERROR: Can't find cell $2.
12. setparam_type #ERROR: Found error in internal cell \top.$procdff$4 ($dff) at kernel/rtlil.cc:715:

simple & misc
===========
Note that some of commands you can not test with checking with testbench
so those place in misc.

1. passes/cmds/add.cc
Note that here you need to load some existing verilog and add additional
wires, inputs or outputs
2. passes/cmds/blackbox.cc
you could create design with sub module, execute blackbox  and check if
sub module is replaced with blackbox module.
3. passes/cmds/bugpoint.cc

4. passes/cmds/chformal.cc

5. passes/cmds/chtype.cc

6. passes/cmds/connect.cc
Maybe can be covered together with add command

7.passes/cmds/connwrappers.cc

8. passes/cmds/design.cc
missing covering -import option

9.passes/cmds/plugin.cc

10. passes/cmds/rename.cc
rename parts of existing design

11. /passes/cmds/select.cc
Lot of options is not used , so room to improve

12.passes/cmds/setattr.cc
note there are 3 commands to cover here

13. passes/cmds/setundef.cc
setting with one, anyseq, anyconst ...

14. passes/sat/assertpmux.cc
15. passes/sat/async2sync.cc
16. passes/sat/eval.cc
17. passes/sat/freduce.cc
18. passes/sat/miter.cc
run with -assert option
19. passes/sat/sat.cc
many options are not tested
20. passes/sat/sim.cc

21. passes/techmap/flowmap.cc