### PR TITLE
Add more complex example to test "opt_rmdff -sat" command

### DIFF
--- a/misc/opt_rmdff_sat/bc.v
+++ b/misc/opt_rmdff_sat/bc.v
@@ -1,0 +1,44 @@
+
+module bc #(
+            parameter SIZE=2,
+            parameter WIDTH=16
+            )
+   (
+    input                        clk,
+    input                        rst,
+
+    output wire                  din_ready,
+    input wire                   din_valid,
+    input wire [WIDTH-1:0]       din_data,
+
+    input wire [SIZE-1:0]        dout_ready,
+    output wire [SIZE-1:0]       dout_valid,
+    output wire [WIDTH*SIZE-1:0] dout_data
+    );
+
+   reg [SIZE-1 : 0] ready_reg;
+   wire [SIZE-1 : 0] ready_all;
+   genvar           i;
+
+   initial begin
+      ready_reg = 0;
+   end
+
+   generate
+      for (i = 0; i < SIZE; i=i+1) begin
+         assign ready_all[i]  = dout_ready[i] | ready_reg[i];
+         assign dout_valid[i] = din_valid & !ready_reg[i];
+         assign dout_data[(i+1)*WIDTH-1:i*WIDTH]   = din_data;
+
+         always @(posedge clk) begin
+            if (rst || (!din_valid) || din_ready) begin
+               ready_reg[i] <= 1'b0;
+            end else if (dout_ready[i]) begin
+               ready_reg[i] <= 1'b1;
+            end
+         end
+      end
+   endgenerate
+   assign din_ready = &ready_all;
+
+endmodule

--- a/misc/opt_rmdff_sat/demux.v
+++ b/misc/opt_rmdff_sat/demux.v
@@ -1,0 +1,57 @@
+
+module demux
+(
+    input clk,
+    input rst,
+    output reg  din_ready,
+    input  wire din_valid,
+    input  wire [2:0] din_data,
+    input  wire         dout0_ready,
+    output reg          dout0_valid,
+    output wire  [0:0] dout0_data,
+    input  wire         dout1_ready,
+    output reg          dout1_valid,
+    output wire  [1:0] dout1_data
+
+);
+    wire [2:0] din_s; // u1 | u2
+    wire [1:0] din_s_data; // u2
+    assign din_s_data = din_s[1:0];
+    wire [0:0] din_s_ctrl; // u1
+    assign din_s_ctrl = din_s[2:2];
+
+
+    assign din_s = din_data;
+
+
+    assign dout0_data = din_data;
+    assign dout1_data = din_data;
+
+    always @*
+    begin
+        din_ready = 1'bx;
+        dout0_valid = 0;
+        dout1_valid = 0;
+
+        if (din_valid) begin
+            case(din_s_ctrl)
+                0 : begin
+                    din_ready = dout0_ready;
+                    dout0_valid = din_valid;
+                end
+                1 : begin
+                    din_ready = dout1_ready;
+                    dout1_valid = din_valid;
+                end
+                default: begin
+                    din_ready = 1'bx;
+                    dout0_valid = 1'bx;
+                    dout1_valid = 1'bx;
+                end
+            endcase
+        end
+    end
+
+
+
+endmodule

--- a/misc/opt_rmdff_sat/mux.v
+++ b/misc/opt_rmdff_sat/mux.v
@@ -1,0 +1,77 @@
+
+module mux
+(
+    input clk,
+    input rst,
+    output reg  ctrl_ready,
+    input  wire ctrl_valid,
+    input  wire [0:0] ctrl_data,
+    output reg  din0_ready,
+    input  wire din0_valid,
+    input  wire [0:0] din0_data,
+    output reg  din1_ready,
+    input  wire din1_valid,
+    input  wire [1:0] din1_data,
+    input  wire         dout_ready,
+    output reg          dout_valid,
+    output wire  [2:0] dout_data
+
+);
+    wire [0:0] ctrl_s; // u1
+
+    wire [0:0] din0_s; // u1
+
+    wire [1:0] din1_s; // u2
+
+    reg [2:0] dout_s; // u1 | u2
+    reg [1:0] dout_s_data; // u2
+    assign dout_s[1:0] = dout_s_data;
+    reg [0:0] dout_s_ctrl; // u1
+    assign dout_s[2:2] = dout_s_ctrl;
+
+
+    assign ctrl_s = ctrl_data;
+    assign din0_s = din0_data;
+    assign din1_s = din1_data;
+
+    assign dout_data = dout_s;
+
+    wire handshake;
+    reg din_valid_sel;
+
+    assign handshake = dout_valid && dout_ready;
+
+    always @*
+    begin
+        din0_ready = din0_valid ? 0 : dout_ready;
+        din1_ready = din1_valid ? 0 : dout_ready;
+        dout_s_data = { 2 {1'bx}};
+        din_valid_sel = 0;
+        if (ctrl_valid) begin
+            case( ctrl_data )
+                0 : begin
+                    din_valid_sel = din0_valid;
+                    dout_s_data[0:0] = din0_s;
+                    din0_ready = din0_valid ? handshake : dout_ready;
+                end
+                1 : begin
+                    din_valid_sel = din1_valid;
+                    dout_s_data[1:0] = din1_s;
+                    din1_ready = din1_valid ? handshake : dout_ready;
+                end
+                default: begin
+                    din0_ready = dout_ready;
+                    din1_ready = dout_ready;
+                    din_valid_sel = 1'bx;
+                end
+            endcase
+        end
+    end
+
+    assign ctrl_ready = ctrl_valid ? handshake : dout_ready;
+    assign dout_s_ctrl = ctrl_s;
+    assign dout_valid = ctrl_valid && din_valid_sel;
+
+
+
+endmodule

--- a/misc/opt_rmdff_sat/top.v
+++ b/misc/opt_rmdff_sat/top.v
@@ -1,0 +1,84 @@
+module top(
+    input clk,
+    input rst,
+
+    output wire  din_ready,
+    input  wire din_valid,
+    input  wire [2:0] din_data,
+    input  wire         dout_ready,
+    output wire          dout_valid,
+    output wire  [2:0] dout_data
+
+);
+
+   wire                dout1_ready;
+   wire                dout1_valid;
+   wire [0:0]          dout1_data;
+
+   wire                dout2_ready;
+   wire                dout2_valid;
+   wire [1:0]          dout2_data;
+
+   wire [1:0]          din_bc_ready;
+   wire [1:0]          din_bc_valid;
+   wire [5:0]          din_bc_data;
+
+   bc #(
+        .SIZE(2'd2),
+        .WIDTH(2'd3)
+        )
+   bc_din (
+           .clk(clk),
+           .rst(rst),
+
+           .din_valid(din_valid),
+           .din_ready(din_ready),
+           .din_data(din_data),
+
+           .dout_valid(din_bc_valid),
+           .dout_ready(din_bc_ready),
+           .dout_data(din_bc_data)
+           );
+
+
+   demux demux (
+                           .clk(clk),
+                           .rst(rst),
+
+                           .din_valid(din_bc_valid[0]),
+                           .din_ready(din_bc_ready[0]),
+                           .din_data(din_bc_data[2:0]),
+
+                           .dout0_valid(dout1_valid),
+                           .dout0_ready(dout1_ready),
+                           .dout0_data(dout1_data),
+
+                           .dout1_valid(dout2_valid),
+                           .dout1_ready(dout2_ready),
+                           .dout1_data(dout2_data)
+                           );
+
+   mux mux (
+            .clk(clk),
+            .rst(rst),
+
+            .ctrl_valid(din_bc_valid[1]),
+            .ctrl_ready(din_bc_ready[1]),
+            .ctrl_data(din_bc_data[2]),
+
+            .din0_valid(dout1_valid),
+            .din0_ready(dout1_ready),
+            .din0_data(dout1_data),
+
+            .din1_valid(dout2_valid),
+            .din1_ready(dout2_ready),
+            .din1_data(dout2_data),
+
+            .dout_valid(dout_valid),
+            .dout_ready(dout_ready),
+            .dout_data(dout_data)
+            );
+
+
+
+endmodule

--- a/misc/scripts/opt_rmdff_sat.ys
+++ b/misc/scripts/opt_rmdff_sat.ys
@@ -1,0 +1,9 @@
+read_verilog  ../top.v
+read_verilog  ../bc.v
+read_verilog  ../demux.v
+read_verilog  ../mux.v
+
+prep -flatten
+opt_rmdff -sat
+synth
+tee -o result.log select -assert-count 0 t:$_DFF_P_


### PR DESCRIPTION
Example involves a more complex logic expressions for DFF next state which allows the DFF to be optimized away using SAT. It also results in two separate DFF cells that are optimized away separately. 