### PR TITLE
regression/run: timeout on issue_01118

### DIFF
--- a/regression/run.sh
+++ b/regression/run.sh
@@ -248,7 +248,13 @@ elif [ "$1" = "issue_00502" ] ||\
 		expected_string="\$pmux                           1"
 	fi
 
-	yosys -ql yosys.log ../../scripts/$2.ys;
+	if [ "$1" = "issue_01118" ]; then
+		# This issue manifests as an infinite loop.
+		timeout 5s yosys -ql yosys.log ../../scripts/$2.ys;
+	else
+		yosys -ql yosys.log ../../scripts/$2.ys;
+	fi
+
 	if [ $? != 0 ] ; then
     	echo FAIL > ${1}_${2}.status
     	touch .stamp


### PR DESCRIPTION
This issue manifests itself as an infinite loop. In case we either regress or test against a broken version, we want the test suite to not hang indefinitely, but fail this test explicitly.