### PR TITLE
Fix failed tests for ice40_wrapcarry; Add tests for new options.

### DIFF
--- a/architecture/Makefile
+++ b/architecture/Makefile
@@ -39,7 +39,7 @@ $(eval $(call template,synth_coolrunner2_error,synth_coolrunner2_fully_selected)
 $(eval $(call template,synth_easic_error,synth_easic_fully_selected))
 
 #ecp5
-$(eval $(call template,synth_ecp5,synth_ecp5 synth_ecp5_top synth_ecp5_blif synth_ecp5_edif synth_ecp5_json synth_ecp5_run synth_ecp5_flatten synth_ecp5_noflatten synth_ecp5_retime synth_ecp5_noccu2 synth_ecp5_nodffe synth_ecp5_nobram synth_ecp5_nodram synth_ecp5_nomux synth_ecp5_abc2 synth_ecp5_vpr ecp5_ffinit synth_ecp5_abc9 synth_ecp5_abc9_nowidelut))
+$(eval $(call template,synth_ecp5,synth_ecp5 synth_ecp5_top synth_ecp5_blif synth_ecp5_edif synth_ecp5_json synth_ecp5_run synth_ecp5_flatten synth_ecp5_noflatten synth_ecp5_retime synth_ecp5_noccu2 synth_ecp5_nodffe synth_ecp5_nobram synth_ecp5_nodram synth_ecp5_nomux synth_ecp5_abc2 synth_ecp5_vpr ecp5_ffinit synth_ecp5_abc9 synth_ecp5_abc9_nowidelut synth_ecp5_nodsp))
 $(eval $(call template,synth_ecp5_wide_ffs,synth_ecp5 synth_ecp5_top synth_ecp5_blif synth_ecp5_edif synth_ecp5_json synth_ecp5_run synth_ecp5_flatten synth_ecp5_noflatten synth_ecp5_retime synth_ecp5_noccu2 synth_ecp5_nodffe synth_ecp5_nobram synth_ecp5_nodram synth_ecp5_nomux synth_ecp5_abc2 synth_ecp5_vpr ecp5_ffinit  synth_ecp5_abc9 synth_ecp5_abc9_nowidelut))
 $(eval $(call template,synth_ecp5_error,synth_ecp5_fully_selected))
 
@@ -71,9 +71,10 @@ $(eval $(call template,synth_sf2,synth_sf2 synth_sf2_top synth_sf2_edif synth_sf
 $(eval $(call template,synth_sf2_error,synth_sf2_fully_selected ))
 
 #xilinx
-$(eval $(call template,synth_xilinx,synth_xilinx synth_xilinx_top synth_xilinx_blif synth_xilinx_edif synth_xilinx_run synth_xilinx_flatten synth_xilinx_retime synth_xilinx_vpr synth_xilinx_arch_xcup synth_xilinx_arch_xcu synth_xilinx_arch_xc7 synth_xilinx_arch_xc6s synth_xilinx_nobram synth_xilinx_nodram synth_xilinx_nosrl synth_xilinx_widemux synth_xilinx_nowidelut synth_xilinx_nocarry synth_xilinx_arch_xc6s_abc9 synth_xilinx_widemux_9 synth_xilinx_widemux_2 synth_xilinx_widemux_3 synth_xilinx_nowidelut_abc9 xilinx_srl_minlen_variable xilinx_srl_minlen))
+$(eval $(call template,synth_xilinx,synth_xilinx synth_xilinx_top synth_xilinx_blif synth_xilinx_edif synth_xilinx_run synth_xilinx_flatten synth_xilinx_retime synth_xilinx_vpr synth_xilinx_arch_xcup synth_xilinx_arch_xcu synth_xilinx_arch_xc7 synth_xilinx_arch_xc6s synth_xilinx_nobram synth_xilinx_nodram synth_xilinx_nosrl synth_xilinx_widemux synth_xilinx_nowidelut synth_xilinx_nocarry synth_xilinx_arch_xc6s_abc9 synth_xilinx_widemux_9 synth_xilinx_widemux_2 synth_xilinx_widemux_3 synth_xilinx_nowidelut_abc9 xilinx_srl_minlen_variable xilinx_srl_minlen synth_xilinx_nodsp synth_xilinx_noclkbuf synth_xilinx_noiopad synth_xilinx_iopad synth_xilinx_ise synth_xilinx_flatten_before_abc synth_xilinx_arch_xc6v))
 $(eval $(call template,synth_xilinx_error,synth_xilinx_fully_selected synth_xilinx_invalid_arch synth_xilinx_abc9_retime synth_xilinx_widemux_1))
 $(eval $(call template,xilinx_srl,xilinx_srl_minlen xilinx_srl_fixed xilinx_srl_variable xilinx_srl_minlen_variable))
+$(eval $(call template,synth_xilinx_dsp_cov,synth_xilinx_dsp))
 ifeq ($(ENABLE_HEAVY_TESTS),1)
 $(eval $(call template,synth_xilinx_srl,synth_xilinx_srl))
 $(eval $(call template,synth_xilinx_mux,synth_xilinx_mux))

--- a/architecture/run.sh
+++ b/architecture/run.sh
@@ -100,9 +100,9 @@ else
 	elif [ "$1" = "synth_ice40_fulladder" ]; then
 		iverilog -o testbench  ../testbench.v synth.v ../../common.v $COMMON_PREFIX/simcells.v $TECHLIBS_PREFIX/ice40/cells_sim.v
 	elif [ "$1" = "ice40_wrapcarry" ]; then
-		iverilog -o testbench  ../testbench.v synth.v ../../common.v $COMMON_PREFIX/simcells.v $TECHLIBS_PREFIX/ice40/cells_sim.v  $TECHLIBS_PREFIX/ice40/abc_model.v
+		iverilog -o testbench  ../testbench.v synth.v ../../common.v $COMMON_PREFIX/simcells.v $TECHLIBS_PREFIX/ice40/cells_sim.v  $TECHLIBS_PREFIX/ice40/abc9_model.v
 	elif [ "$1" = "ice40_wrapcarry_adders" ]; then
-		iverilog -o testbench  ../testbench.v synth.v ../../common.v $COMMON_PREFIX/simcells.v $TECHLIBS_PREFIX/ice40/cells_sim.v  $TECHLIBS_PREFIX/ice40/abc_model.v
+		iverilog -o testbench  ../testbench.v synth.v ../../common.v $COMMON_PREFIX/simcells.v $TECHLIBS_PREFIX/ice40/cells_sim.v  $TECHLIBS_PREFIX/ice40/abc9_model.v
 	elif [ "$1" = "synth_intel" ]; then
 		iverilog -o testbench  ../testbench.v synth.v ../../common.v $COMMON_PREFIX/simcells.v $TECHLIBS_PREFIX/intel/max10/cells_sim.v
 	elif [ "$1" = "synth_intel_a10gx" ]; then
@@ -131,7 +131,8 @@ else
 		iverilog -o testbench  ../testbench.v synth.v ../../common.v $COMMON_PREFIX/simcells.v $TECHLIBS_PREFIX/efinix/cells_sim.v
 	elif [ "$1" = "synth_efinix_fulladder" ]; then
 		iverilog -o testbench  ../testbench.v synth.v ../../common.v $COMMON_PREFIX/simcells.v $TECHLIBS_PREFIX/efinix/cells_sim.v
-	elif [ "$1" = "xilinx_ug901_synthesis_examples" ]; then
+	elif [ "$1" = "xilinx_ug901_synthesis_examples" ] || \
+		 [ "$1" = "synth_xilinx_dsp_cov" ]; then
 		:
 	else
 		iverilog -o testbench  ../testbench.v synth.v ../../common.v $COMMON_PREFIX/simcells.v
@@ -141,7 +142,8 @@ else
 		touch .stamp
 		exit 0
 	fi
-	if [ "$1" = "xilinx_ug901_synthesis_examples" ]; then
+	if  [ "$1" = "xilinx_ug901_synthesis_examples" ] || \
+		[ "$1" = "synth_xilinx_dsp_cov" ]; then
 		echo PASS > ${1}_${2}.status
 	else
 		if ! vvp -N testbench > testbench.log 2>&1; then

--- a/architecture/scripts/synth_ecp5_nodsp.ys
+++ b/architecture/scripts/synth_ecp5_nodsp.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_ecp5 -nodsp
+write_verilog synth.v

--- a/architecture/scripts/synth_xilinx_arch_xc6v.ys
+++ b/architecture/scripts/synth_xilinx_arch_xc6v.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx -arch xc6v
+write_verilog synth.v

--- a/architecture/scripts/synth_xilinx_dsp.ys
+++ b/architecture/scripts/synth_xilinx_dsp.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx
+select -assert-count 3 t:DSP48E1

--- a/architecture/scripts/synth_xilinx_flatten_before_abc.ys
+++ b/architecture/scripts/synth_xilinx_flatten_before_abc.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx -flatten_before_abc
+write_verilog synth.v

--- a/architecture/scripts/synth_xilinx_iopad.ys
+++ b/architecture/scripts/synth_xilinx_iopad.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx -iopad
+write_verilog synth.v

--- a/architecture/scripts/synth_xilinx_ise.ys
+++ b/architecture/scripts/synth_xilinx_ise.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx -ise
+write_verilog synth.v

--- a/architecture/scripts/synth_xilinx_noclkbuf.ys
+++ b/architecture/scripts/synth_xilinx_noclkbuf.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx -noclkbuf
+write_verilog synth.v

--- a/architecture/scripts/synth_xilinx_nodsp.ys
+++ b/architecture/scripts/synth_xilinx_nodsp.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx -nodsp
+write_verilog synth.v

--- a/architecture/scripts/synth_xilinx_noiopad.ys
+++ b/architecture/scripts/synth_xilinx_noiopad.ys
@@ -1,0 +1,3 @@
+read_verilog ../top.v
+synth_xilinx -noiopad
+write_verilog synth.v

--- a/architecture/synth_xilinx_dsp_cov/top.v
+++ b/architecture/synth_xilinx_dsp_cov/top.v
@@ -1,0 +1,18 @@
+module simd(input [12*4-1:0] a, input [12*4-1:0] b, (* use_dsp="simd" *) output [7*12-1:0] o12, (* use_dsp="simd" *) output [2*24-1:0] o24);
+generate
+    genvar i;
+    // 4 x 12-bit adder
+    for (i = 0; i < 4; i++)
+        assign o12[i*12+:12] = a[i*12+:12] + b[i*12+:12];
+    // 2 x 24-bit subtract
+    for (i = 0; i < 2; i++)
+        assign o24[i*24+:24] = a[i*24+:24] - b[i*24+:24];
+endgenerate
+reg [3*12-1:0] ro;
+always @* begin
+    ro[0*12+:12] = a[0*10+:10] + b[0*10+:10];
+    ro[1*12+:12] = a[1*10+:10] + b[1*10+:10];
+    ro[2*12+:12] = a[2*8+:8] + b[2*8+:8];
+end
+assign o12[4*12+:3*12] = ro;
+endmodule


### PR DESCRIPTION
- Fix abc_model.v to abc9_model.v in techlibs paths;
- synth_xilinx. Add tests for new options;
- synth_ecp5. Add tests for new options;
- Expand coverage for synth_dsp command;