### PR TITLE
Ensure the variable to be specialized is assigned an `$anyconst` cell.

### DIFF
--- a/misc/qbfsat/qbfsat_solnfile3.ys
+++ b/misc/qbfsat/qbfsat_solnfile3.ys
@@ -3,7 +3,7 @@ logger -expect log "Eval result: \\out = 8'00001000." 1
 
 read_verilog -formal <<EOT
 module const_mul(out);
-	wire [7:0] h;
+	wire [7:0] h = $anyconst;
 	output [7:0] out;
 
 	assign out = h[7]? h[6:0] * 3 : h[6:0] * 4;


### PR DESCRIPTION
This eliminates these warnings from the test output:
```
Warning: Wire const_mul.\h [6] is used but has no driver.
Warning: Wire const_mul.\h [5] is used but has no driver.
Warning: Wire const_mul.\h [4] is used but has no driver.
Warning: Wire const_mul.\h [3] is used but has no driver.
Warning: Wire const_mul.\h [2] is used but has no driver.
Warning: Wire const_mul.\h [1] is used but has no driver.
Warning: Wire const_mul.\h [7] is used but has no driver.
Warning: Wire const_mul.\h [0] is used but has no driver.
```